### PR TITLE
Record type checker

### DIFF
--- a/src/check/LwcMetadataChecker.ts
+++ b/src/check/LwcMetadataChecker.ts
@@ -1,13 +1,12 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { AnyJson } from '@salesforce/ts-types';
 
 export class LwcMetadataChecker {
   // Checks over all of the lightning web components in a given lwc folder (full path expected).
   // Right now the only check performed is for trailing whitespace. Any trailing whitespace in a .js-meta.xml file
   // can, for reasons unknown, cause even more whitespace to be added _between_ lines during a Salesforce deployment
   // (which can result in noisy diffs later when the lwc is retrieved). Best to avoid in the first place.
-  public checkLwcFolder(lwcFolder: string): AnyJson {
+  public checkLwcFolder(lwcFolder: string): string[] {
     const lwcs = fs.readdirSync(lwcFolder).filter((entry) => entry !== 'jsconfig.json');
     const warnings: string[] = [];
 
@@ -16,7 +15,7 @@ export class LwcMetadataChecker {
       warnings.push(...this.checkJsMetaFile(jsMetaFileName));
     });
 
-    return { warnings };
+    return warnings;
   }
 
   // Check a single .js-meta.xml file (full path expected).

--- a/src/commands/dxcop/source/check.ts
+++ b/src/commands/dxcop/source/check.ts
@@ -40,24 +40,26 @@ export default class Check extends SfdxCommand {
     const sfdxProject = await SfdxProject.resolve();
     const defaultPackage = sfdxProject.getDefaultPackage();
 
-    const result = this.checkLwcMetadata(defaultPackage);
-    this.checkRecordTypeMetadata(defaultPackage);
+    const lwcWarnings = this.checkLwcMetadata(defaultPackage);
+    const rtWarnings = this.checkRecordTypeMetadata(defaultPackage);
+
+    const warnings = lwcWarnings.concat(rtWarnings);
 
     // Return an object to be displayed with --json
-    return result;
+    return { warnings };
   }
 
-  public checkLwcMetadata(sfdxPackage: NamedPackageDir): AnyJson {
+  public checkLwcMetadata(sfdxPackage: NamedPackageDir): string[] {
     const lwcPath = path.join(sfdxPackage.fullPath, 'main', 'default', 'lwc');
 
     const lwcMetadataChecker = new LwcMetadataChecker();
     return lwcMetadataChecker.checkLwcFolder(lwcPath);
   }
 
-  public checkRecordTypeMetadata(sfdxPackage: NamedPackageDir): void {
+  public checkRecordTypeMetadata(sfdxPackage: NamedPackageDir): string[] {
     const baseDir = path.join(sfdxPackage.fullPath, 'main', 'default');
 
     const recordTypeChecker = new RecordTypeChecker(baseDir);
-    recordTypeChecker.run();
+    return recordTypeChecker.run();
   }
 }


### PR DESCRIPTION
Check record types for the existence of picklist value sets.

When you add a new picklist field to an object, Salesforce will automatically add the picklist and all its values to each record type for the object. However it's common to forget to commit the record types to git when adding a new field, leading to the repo and org becoming out of sync. This check ensures they remain in sync.