### PR TITLE
Email-to-Case checking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.3] - 2022-04-03
+
+Add checks for Email-to-Case settings.
 
 ## [0.0.2] - 2022-03-22
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ When you add a new picklist field to an object, Salesforce automatically adds a 
 
 Checks `*.js-meta.xml` files for extra whitespace at the ends of lines. This can cause unexpected behaviour when you retrieve the same component after deployment; extra lines of whitespace can be inserted resulting in unexpected file differences.
 
+### Email-to-Case settings
+
+Ensures you don't have the `<emailServicesAddress>` and `<isVerified>` fields stored in version control. These are specific to each environment and usually cause validation failures if you try to change them in a deployment, so it's best not to store them at all.
+
+Also ensures that `<routingAddresses>` are ordered by `<routingName>`.
+
 ## Problem categories
 
 ### Errors

--- a/README.md
+++ b/README.md
@@ -73,4 +73,8 @@ Picklists based on **standard value sets** or **global value sets** are currentl
 
 **PersonAccount**, **Event** and **Task** objects are currently ignored. These non-standard objects will require some special handling, which hasn't been built yet.
 
-**ForecastCategoryName** fields are also ignored.
+The **Opportunity.ForecastCategoryName** field is also ignored, for similar reasons.
+
+## Change log
+
+A full history of changes can be viewed in the [change log](https://github.com/dcathcart/dx-cop/blob/master/CHANGELOG.md).

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dx-cop",
   "description": "Static analysis for your Salesforce git repo",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "author": "David Cathcart",
   "bugs": "https://github.com/dcathcart/dx-cop/issues",
   "dependencies": {

--- a/src/check/CheckerBase.ts
+++ b/src/check/CheckerBase.ts
@@ -1,0 +1,9 @@
+import { SfdxProjectBrowser } from '../metadata_browser/SfdxProjectBrowser';
+
+export class CheckerBase {
+  protected sfdxProjectBrowser: SfdxProjectBrowser;
+
+  public constructor(sfdxProjectBrowser: SfdxProjectBrowser) {
+    this.sfdxProjectBrowser = sfdxProjectBrowser;
+  }
+}

--- a/src/check/EmailToCaseSettingsChecker.ts
+++ b/src/check/EmailToCaseSettingsChecker.ts
@@ -1,0 +1,23 @@
+import { EmailToCaseRoutingAddress, EmailToCaseSettings } from '../metadata_browser/EmailToCaseSettings';
+import { CheckerBase } from './CheckerBase';
+import { MetadataError, MetadataProblem } from './MetadataProblem';
+
+export class EmailToCaseSettingsChecker extends CheckerBase {
+  public run(): MetadataProblem[] {
+    const emailToCaseSettings = this.sfdxProjectBrowser.emailToCaseSettings();
+    return this.checkIsVerified(emailToCaseSettings);
+  }
+
+  private checkIsVerified(emailToCaseSettings: EmailToCaseSettings): MetadataProblem[] {
+    return emailToCaseSettings
+      .routingAddresses()
+      .filter((r) => r.isVerified !== undefined)
+      .map((r) => this.metadataError(emailToCaseSettings, r));
+  }
+
+  private metadataError(settings: EmailToCaseSettings, routingAddress: EmailToCaseRoutingAddress): MetadataError {
+    const componentName = 'EmailToCase:' + routingAddress.routingName;
+    const message = '<isVerified> field should not be version-controlled';
+    return new MetadataError(componentName, 'CaseSettings', settings.fileName, message);
+  }
+}

--- a/src/check/EmailToCaseSettingsChecker.ts
+++ b/src/check/EmailToCaseSettingsChecker.ts
@@ -46,8 +46,9 @@ export class EmailToCaseSettingsChecker extends CheckerBase {
 
   // First(ish) go at checking the sort order of metadata.
   // Definitely some potential here for a generic check-the-sort-order-of-something function, which I'll visit in the future.
-  // Why is the sort order important? Because when you deploy, then retrieve the file again, the order will be different.
-  // This can lead to unexpected differences that you need to manage, which can lead to merge conflicts and other problems.
+  // Why is the sort order important? Because when you retrieve this metadata, Salesforce always sorts it by <routingName>.
+  // So if you deploy, then immediately retrieve the file again, the retrieved order will be different.
+  // This can lead to unexpected differences that you need to manage, which can in turn lead to merge conflicts and other problems.
   private checkSortOrder(emailToCaseSettings: EmailToCaseSettings): MetadataProblem[] {
     const results: MetadataProblem[] = [];
     const routingAddresses = emailToCaseSettings.routingAddresses();

--- a/src/check/EmailToCaseSettingsChecker.ts
+++ b/src/check/EmailToCaseSettingsChecker.ts
@@ -5,19 +5,40 @@ import { MetadataError, MetadataProblem } from './MetadataProblem';
 export class EmailToCaseSettingsChecker extends CheckerBase {
   public run(): MetadataProblem[] {
     const emailToCaseSettings = this.sfdxProjectBrowser.emailToCaseSettings();
-    return this.checkIsVerified(emailToCaseSettings);
+    return this.checkRoutingAddresses(emailToCaseSettings);
   }
 
+  private checkRoutingAddresses(emailToCaseSettings: EmailToCaseSettings): MetadataProblem[] {
+    return this.checkEmailServicesAddress(emailToCaseSettings).concat(this.checkIsVerified(emailToCaseSettings));
+  }
+
+  // <emailServicesAddress> should not be stored in version control.
+  // This field is set by Salesforce and it unique for each environment, so you can't deploy it.
+  // In fact trying to change it during a deployment results in a Salesforce validation error.
+  private checkEmailServicesAddress(emailToCaseSettings: EmailToCaseSettings): MetadataProblem[] {
+    return emailToCaseSettings
+      .routingAddresses()
+      .filter((r) => r.emailServicesAddress !== undefined)
+      .map((r) => this.metadataError(emailToCaseSettings, r, 'emailServicesAddress'));
+  }
+
+  // <isVerified> should not be stored in version control.
+  // It specifies whether an email address as been verified and is specific to each environment.
+  // As such it can't be modified in a deployment; doing so will result in a Salesforce validation error.
   private checkIsVerified(emailToCaseSettings: EmailToCaseSettings): MetadataProblem[] {
     return emailToCaseSettings
       .routingAddresses()
       .filter((r) => r.isVerified !== undefined)
-      .map((r) => this.metadataError(emailToCaseSettings, r));
+      .map((r) => this.metadataError(emailToCaseSettings, r, 'isVerified'));
   }
 
-  private metadataError(settings: EmailToCaseSettings, routingAddress: EmailToCaseRoutingAddress): MetadataError {
+  private metadataError(
+    settings: EmailToCaseSettings,
+    routingAddress: EmailToCaseRoutingAddress,
+    fieldName: string
+  ): MetadataError {
     const componentName = 'EmailToCase:' + routingAddress.routingName;
-    const message = '<isVerified> field should not be version-controlled';
+    const message = `<${fieldName}> field should not be version-controlled`;
     return new MetadataError(componentName, 'CaseSettings', settings.fileName, message);
   }
 }

--- a/src/check/LwcMetadataChecker.ts
+++ b/src/check/LwcMetadataChecker.ts
@@ -1,13 +1,21 @@
 import * as fs from 'fs';
 import * as path from 'path';
+import { CheckerBase } from './CheckerBase';
 import { MetadataProblem, MetadataWarning } from './MetadataProblem';
 
-export class LwcMetadataChecker {
+export class LwcMetadataChecker extends CheckerBase {
+  public run(): MetadataProblem[] {
+    // TODO: Move this folder/file logic back to the SfdxProjectBrowser
+    const defaultPackage = this.sfdxProjectBrowser.sfdxProject.getDefaultPackage();
+    const lwcPath = path.join(defaultPackage.fullPath, 'main', 'default', 'lwc');
+    return this.checkLwcFolder(lwcPath);
+  }
+
   // Checks over all of the lightning web components in a given lwc folder (full path expected).
   // Right now the only check performed is for trailing whitespace. Any trailing whitespace in a .js-meta.xml file
   // can, for reasons unknown, cause even more whitespace to be added _between_ lines during a Salesforce deployment
   // (which can result in noisy diffs later when the lwc is retrieved). Best to avoid in the first place.
-  public checkLwcFolder(lwcFolder: string): MetadataProblem[] {
+  private checkLwcFolder(lwcFolder: string): MetadataProblem[] {
     const lwcs = fs.readdirSync(lwcFolder).filter((entry) => entry !== 'jsconfig.json');
     const warnings: MetadataProblem[] = [];
 
@@ -23,7 +31,7 @@ export class LwcMetadataChecker {
   // Returns an array of warnings about the file.
   // (okay, so right now there will only every be zero or one warnings, because we only check for one thing,
   // i.e. trailing whitespace. Writing it this way with the future in mind)
-  public checkJsMetaFile(lwcName: string, jsMetaFilename: string): MetadataProblem[] {
+  private checkJsMetaFile(lwcName: string, jsMetaFilename: string): MetadataProblem[] {
     const warnings: MetadataProblem[] = [];
 
     if (this.fileHasTrailingWhitespace(jsMetaFilename)) {
@@ -40,7 +48,7 @@ export class LwcMetadataChecker {
     return warnings;
   }
 
-  public fileHasTrailingWhitespace(filename: string): boolean {
+  private fileHasTrailingWhitespace(filename: string): boolean {
     const file = fs.readFileSync(filename);
     const fileContents = file.toString();
     const lines = fileContents.split(/\r\n|\n|\r/); // handle DOS|Unix|old Mac line endings
@@ -48,7 +56,7 @@ export class LwcMetadataChecker {
     return result;
   }
 
-  public hasTrailingWhitespace(input: string): boolean {
+  private hasTrailingWhitespace(input: string): boolean {
     return input !== input.trimEnd();
   }
 }

--- a/src/check/RecordTypePicklistChecker.ts
+++ b/src/check/RecordTypePicklistChecker.ts
@@ -1,15 +1,10 @@
 import { RecordType } from '../metadata_browser/RecordType';
-import { SfdxProjectBrowser } from '../metadata_browser/SfdxProjectBrowser';
+import { CheckerBase } from './CheckerBase';
 import { MetadataError, MetadataProblem, MetadataWarning } from './MetadataProblem';
 
-export class RecordTypePicklistChecker {
+export class RecordTypePicklistChecker extends CheckerBase {
   private IGNORE_OBJECTS = ['Event', 'PersonAccount', 'Task'];
   private BONUS_EXPECTED_PICKLISTS = ['Name', 'ForecastCategoryName'];
-  private sfdxProjectBrowser: SfdxProjectBrowser;
-
-  public constructor(sfdxProjectBrowser: SfdxProjectBrowser) {
-    this.sfdxProjectBrowser = sfdxProjectBrowser;
-  }
 
   public run(): MetadataProblem[] {
     const warnings: MetadataProblem[] = [];

--- a/src/check/RecordTypePicklistValueChecker.ts
+++ b/src/check/RecordTypePicklistValueChecker.ts
@@ -1,17 +1,11 @@
 import { PicklistField } from '../metadata_browser/PicklistField';
 import { RecordType } from '../metadata_browser/RecordType';
-import { SfdxProjectBrowser } from '../metadata_browser/SfdxProjectBrowser';
+import { CheckerBase } from './CheckerBase';
 import { MetadataError, MetadataProblem } from './MetadataProblem';
 
-export class RecordTypePicklistValueChecker {
+export class RecordTypePicklistValueChecker extends CheckerBase {
   private IGNORE_OBJECTS = ['Event', 'PersonAccount', 'Task'];
   private IGNORE_PICKLISTS = ['ForecastCategoryName'];
-
-  private sfdxProjectBrowser: SfdxProjectBrowser;
-
-  public constructor(sfdxProjectBrowser: SfdxProjectBrowser) {
-    this.sfdxProjectBrowser = sfdxProjectBrowser;
-  }
 
   // Run the record type picklist value checks. Returns an array of warning messages.
   public run(): MetadataProblem[] {

--- a/src/commands/dxcop/source/check.ts
+++ b/src/commands/dxcop/source/check.ts
@@ -35,12 +35,13 @@ export default class Check extends SfdxCommand {
     metadataProblems.push(...this.checkRecordTypePicklistMetadata(sfdxProjectBrowser));
 
     // Log output as a pretty table. Note it won't be shown if --json was passed
+    this.ux.log(); // blank line first
     const problemCount = metadataProblems.length;
     if (problemCount === 0) {
       this.ux.log('Successfully checked metadata. No problems found!');
     } else {
       const tableData = metadataProblems.map((p) => p.tableOutput());
-      this.ux.log(`\n=== Metadata Problems [${problemCount}]`);
+      this.ux.log(`=== Metadata Problems [${problemCount}]`);
       this.ux.table(tableData, MetadataProblem.tableOutputKeys);
     }
 

--- a/src/commands/dxcop/source/check.ts
+++ b/src/commands/dxcop/source/check.ts
@@ -3,12 +3,12 @@ import { SfdxCommand } from '@salesforce/command';
 import { Messages, SfdxProject } from '@salesforce/core';
 import { AnyJson } from '@salesforce/ts-types';
 
+import { EmailToCaseSettingsChecker } from '../../../check/EmailToCaseSettingsChecker';
 import { LwcMetadataChecker } from '../../../check/LwcMetadataChecker';
 import { MetadataProblem } from '../../../check/MetadataProblem';
 import { RecordTypePicklistChecker } from '../../../check/RecordTypePicklistChecker';
 import { RecordTypePicklistValueChecker } from '../../../check/RecordTypePicklistValueChecker';
 import { SfdxProjectBrowser } from '../../../metadata_browser/SfdxProjectBrowser';
-import { EmailToCaseSettingsChecker } from '../../../check/EmailToCaseSettingsChecker';
 
 // Initialize Messages with the current plugin directory
 Messages.importMessagesDirectory(__dirname);

--- a/src/commands/dxcop/source/check.ts
+++ b/src/commands/dxcop/source/check.ts
@@ -56,22 +56,22 @@ export default class Check extends SfdxCommand {
   }
 
   public checkEmailToCaseSettings(sfdxProjectBrowser: SfdxProjectBrowser): MetadataProblem[] {
-    this.ux.log('Checking email-to-case settings...');
+    this.ux.log('Checking email-to-case settings');
     return new EmailToCaseSettingsChecker(sfdxProjectBrowser).run();
   }
 
   public checkLwcMetadata(sfdxProjectBrowser: SfdxProjectBrowser): MetadataProblem[] {
-    this.ux.log('Checking lwc metadata...');
+    this.ux.log('Checking lwc metadata');
     return new LwcMetadataChecker(sfdxProjectBrowser).run();
   }
 
   public checkRecordTypeMetadata(sfdxProjectBrowser: SfdxProjectBrowser): MetadataProblem[] {
-    this.ux.log('Checking record type picklists...');
+    this.ux.log('Checking record type picklists');
     return new RecordTypePicklistChecker(sfdxProjectBrowser).run();
   }
 
   public checkRecordTypePicklistMetadata(sfdxProjectBrowser: SfdxProjectBrowser): MetadataProblem[] {
-    this.ux.log('Checking record type picklist values...');
+    this.ux.log('Checking record type picklist values');
     return new RecordTypePicklistValueChecker(sfdxProjectBrowser).run();
   }
 }

--- a/src/metadata_browser/EmailToCaseSettings.ts
+++ b/src/metadata_browser/EmailToCaseSettings.ts
@@ -1,4 +1,13 @@
-import { AnyJson, JsonMap, getJsonArray, getJsonMap, getString, hasJsonArray, hasJsonMap } from '@salesforce/ts-types';
+import {
+  AnyJson,
+  JsonMap,
+  getBoolean,
+  getJsonArray,
+  getJsonMap,
+  getString,
+  hasJsonArray,
+  hasJsonMap,
+} from '@salesforce/ts-types';
 import { ComponentBase } from './ComponentBase';
 
 export class EmailToCaseSettings extends ComponentBase {
@@ -31,6 +40,14 @@ export class EmailToCaseRoutingAddress {
 
   public constructor(source: AnyJson) {
     this.source = source;
+  }
+
+  public get emailServicesAddress(): string {
+    return getString(this.source, 'emailServicesAddress');
+  }
+
+  public get isVerified(): boolean {
+    return getBoolean(this.source, 'isVerified');
   }
 
   public get routingName(): string {

--- a/src/metadata_browser/EmailToCaseSettings.ts
+++ b/src/metadata_browser/EmailToCaseSettings.ts
@@ -1,0 +1,39 @@
+import { AnyJson, JsonMap, getJsonArray, getJsonMap, getString, hasJsonArray, hasJsonMap } from '@salesforce/ts-types';
+import { ComponentBase } from './ComponentBase';
+
+export class EmailToCaseSettings extends ComponentBase {
+  protected fileExtension = 'settings';
+
+  public routingAddresses(): EmailToCaseRoutingAddress[] {
+    if (hasJsonArray(this.emailToCaseSettings, 'routingAddresses')) {
+      const routingAddressArray = getJsonArray(this.emailToCaseSettings, 'routingAddresses');
+      return routingAddressArray.map((r) => new EmailToCaseRoutingAddress(r));
+    } else if (hasJsonMap(this.emailToCaseSettings, 'routingAddresses')) {
+      const routingAddressMap = getJsonMap(this.emailToCaseSettings, 'routingAddresses');
+      const routingAddress = new EmailToCaseRoutingAddress(routingAddressMap);
+      return [routingAddress];
+    } else {
+      return [];
+    }
+  }
+
+  private get emailToCaseSettings(): JsonMap {
+    return getJsonMap(this.roolElement, 'emailToCase');
+  }
+
+  private get roolElement(): JsonMap {
+    return getJsonMap(this.metadata, 'CaseSettings');
+  }
+}
+
+export class EmailToCaseRoutingAddress {
+  private readonly source: AnyJson;
+
+  public constructor(source: AnyJson) {
+    this.source = source;
+  }
+
+  public get routingName(): string {
+    return getString(this.source, 'routingName');
+  }
+}

--- a/src/metadata_browser/SfdxProjectBrowser.ts
+++ b/src/metadata_browser/SfdxProjectBrowser.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { SfdxProject } from '@salesforce/core';
 import { CustomField } from './CustomField';
+import { EmailToCaseSettings } from './EmailToCaseSettings';
 import { PicklistField } from './PicklistField';
 import { RecordType } from './RecordType';
 
@@ -11,6 +12,11 @@ export class SfdxProjectBrowser {
 
   public constructor(sfdxProject: SfdxProject) {
     this.sfdxProject = sfdxProject;
+  }
+
+  public emailToCaseSettings(): EmailToCaseSettings {
+    const fileName = path.join(this.settingsBaseDir(), 'Case.settings-meta.xml');
+    return new EmailToCaseSettings(fileName);
   }
 
   // Return a list of object names
@@ -57,6 +63,10 @@ export class SfdxProjectBrowser {
   // Directory containing custom objects
   private objectsBaseDir(): string {
     return path.join(this.defaultDir(), 'objects');
+  }
+
+  private settingsBaseDir(): string {
+    return path.join(this.defaultDir(), 'settings');
   }
 
   // Where to look for metadata XML files.

--- a/src/metadata_browser/SfdxProjectBrowser.ts
+++ b/src/metadata_browser/SfdxProjectBrowser.ts
@@ -7,7 +7,7 @@ import { RecordType } from './RecordType';
 
 // Tools for browsing/navigating the metadata in an SFDX project
 export class SfdxProjectBrowser {
-  private sfdxProject: SfdxProject;
+  public readonly sfdxProject: SfdxProject;
 
   public constructor(sfdxProject: SfdxProject) {
     this.sfdxProject = sfdxProject;


### PR DESCRIPTION
New class to look over the `<EmailToCase>` settings in **Case.settings-meta.xml**.

- Metadata Error if `<isVerified>` or `<emailServicesAddress>` fields exist in the metadata. These are specific to each environment and cannot be changed in deployments, so should be kept out of source control completely.
- Metadata Warning if `<routingAddresses>` aren't sorted correctly by `<routingName>`. Not likely to cause deployment errors, but can still cause surprises if source & org aren't kept exactly in sync.