### PR TITLE
Fix for Email-to-Case sort order check 

### DIFF
--- a/src/check/EmailToCaseSettingsChecker.ts
+++ b/src/check/EmailToCaseSettingsChecker.ts
@@ -57,7 +57,7 @@ export class EmailToCaseSettingsChecker extends CheckerBase {
       const a = routingAddresses[i - 1];
       const b = routingAddresses[i];
 
-      if (a.routingName >= b.routingName) {
+      if (a.routingName > b.routingName) {
         results.push(this.sortOrderWarning(emailToCaseSettings, a, b));
       }
     }

--- a/src/test/check/EmailToCaseSettingsChecker.test.ts
+++ b/src/test/check/EmailToCaseSettingsChecker.test.ts
@@ -2,7 +2,7 @@ import 'mocha';
 import * as path from 'path';
 import { expect } from 'chai';
 import * as sinon from 'sinon';
-import { EmailToCaseSettings } from '../../metadata_browser/EmailToCaseSettings';
+import { EmailToCaseRoutingAddress, EmailToCaseSettings } from '../../metadata_browser/EmailToCaseSettings';
 import { EmailToCaseSettingsChecker } from '../../check/EmailToCaseSettingsChecker';
 import { SfdxProjectBrowser } from '../../metadata_browser/SfdxProjectBrowser';
 
@@ -92,6 +92,20 @@ describe('EmailToCaseSettingsChecker', () => {
         "<routingAddresses> should be sorted by <routingName>. Expect 'Test email address 2' to be before 'Test email address 3'"
       );
       expect(result[0].problemType).to.equal('Warning');
+    });
+
+    it('should not return an error when two adjacent <routingAddresses> have the same <routingName>', () => {
+      const routingAddresses = [
+        new EmailToCaseRoutingAddress({ routingName: 'Entry 1' }),
+        new EmailToCaseRoutingAddress({ routingName: 'Entry 1' }),
+        new EmailToCaseRoutingAddress({ routingName: 'Entry 2' }),
+      ];
+      const emailToCaseSettings = new EmailToCaseSettings('');
+      sinon.stub(emailToCaseSettings, 'routingAddresses').returns(routingAddresses);
+
+      const checker = new EmailToCaseSettingsChecker(null);
+      const results = checker['sortOrderWarnings'](emailToCaseSettings);
+      expect(results.length).to.equal(0);
     });
 
     it('should return an empty array when there are no errors', () => {

--- a/src/test/check/EmailToCaseSettingsChecker.test.ts
+++ b/src/test/check/EmailToCaseSettingsChecker.test.ts
@@ -80,16 +80,23 @@ describe('EmailToCaseSettingsChecker', () => {
 
   describe('.sortOrderWarnings()', () => {
     it("should return a metadata error when <routingAddresses> aren't sorted by <routingName>", () => {
-      const fileName = path.normalize('src/test/fixtures/settings/Case-errors.settings-meta.xml');
-      const emailToCaseSettings = new EmailToCaseSettings(fileName);
+      const routingAddresses = [
+        new EmailToCaseRoutingAddress({ routingName: 'Entry 1' }),
+        new EmailToCaseRoutingAddress({ routingName: 'Entry 3' }),
+        new EmailToCaseRoutingAddress({ routingName: 'Entry 2' }),
+      ];
+      const emailToCaseSettings = new EmailToCaseSettings('');
+      sinon.stub(emailToCaseSettings, 'routingAddresses').returns(routingAddresses);
+      sinon.stub(emailToCaseSettings, 'fileName').get(() => 'Case.settings-meta.xml');
+
       const checker = new EmailToCaseSettingsChecker(null);
       const result = checker['sortOrderWarnings'](emailToCaseSettings);
       expect(result.length).to.equal(1);
       expect(result[0].componentType).to.equal('CaseSettings');
       expect(result[0].componentName).to.equal('EmailToCase');
-      expect(result[0].fileName).to.equal(fileName);
+      expect(result[0].fileName).to.equal('Case.settings-meta.xml');
       expect(result[0].problem).to.equal(
-        "<routingAddresses> should be sorted by <routingName>. Expect 'Test email address 2' to be before 'Test email address 3'"
+        "<routingAddresses> should be sorted by <routingName>. Expect 'Entry 2' to be before 'Entry 3'"
       );
       expect(result[0].problemType).to.equal('Warning');
     });


### PR DESCRIPTION
### Issue

In Case.settings-meta.xml -> `<emailToCase>` section, we check that the `<routingAddresses>` are sorted by `<routingName>`. However as it happens, Salesforce allows multiple entries with the same `<routingName>`. This was resulting in a metadata warning that looked something like: 
```
<routingAddresses> should be sorted by <routingName>. Expect 'Entry 1' to be before 'Entry 1'
```

### Fix

Allow 2 adjacent entries with the same `<routingName>` to exist without raising a warning.