### PR TITLE
Fix for Admin Profile ruleset

### DIFF
--- a/src/ruleset/adminProfileRuleset.test.ts
+++ b/src/ruleset/adminProfileRuleset.test.ts
@@ -24,7 +24,7 @@ describe('AdminProfileRuleset', () => {
       mockProjectBrowser.expects('objects').once().returns(objects);
 
       const ruleset = new AdminProfileRuleset(sfdxProjectBrowser);
-      const results = ruleset['expectedObjects']();
+      const results = ruleset['objectsToCheck']();
       expect(results.length).to.equal(1);
       expect(results[0].name).to.equal('Object2__c');
 
@@ -44,7 +44,7 @@ describe('AdminProfileRuleset', () => {
       mockProjectBrowser.expects('fields').once().withArgs('Object1').returns([]);
       mockProjectBrowser.expects('fields').once().withArgs('Object2__c').returns([]);
       const ruleset = new AdminProfileRuleset(sfdxProjectBrowser);
-      ruleset['expectedFields'](objects);
+      ruleset['fieldsToCheck'](objects);
       mockProjectBrowser.verify();
     });
     it('only checks custom fields that are not required', () => {
@@ -62,7 +62,7 @@ describe('AdminProfileRuleset', () => {
 
       mockProjectBrowser.expects('fields').once().withArgs('Object1').returns([field1, field2]);
       const ruleset = new AdminProfileRuleset(sfdxProjectBrowser);
-      const results = ruleset['expectedFields'](objects);
+      const results = ruleset['fieldsToCheck'](objects);
       expect(results.length).to.equal(1);
       expect(results[0]).to.equal(field2);
       mockProjectBrowser.verify();
@@ -98,13 +98,14 @@ describe('AdminProfileRuleset', () => {
   describe('.missingFieldPermissions()', () => {
     it('should return a list of warnings for field permissions that are false, but should be true', () => {
       const profile = new Profile('Admin.profile-meta.xml');
+      const fields = [new CustomField('path/to/objects/Object1/fields/Field1.field-meta.xml')];
       const fieldPermissions = [
         new ProfileFieldPermission({ editable: false, field: 'Object1.Field1', readable: false }),
       ];
       sinon.stub(profile, 'fieldPermissions').returns(fieldPermissions);
 
       const ruleset = new AdminProfileRuleset(null);
-      const results = ruleset['missingFieldPermissions'](profile);
+      const results = ruleset['missingFieldPermissions'](profile, fields);
       expect(results.length).to.equal(2);
 
       expect(results[0].componentName).to.equal('Admin');

--- a/src/ruleset/adminProfileRuleset.ts
+++ b/src/ruleset/adminProfileRuleset.ts
@@ -56,20 +56,15 @@ export class AdminProfileRuleset extends MetadataRuleset {
     const fieldNamesToCheck = fieldsToCheck.map((f) => f.objectFieldName());
 
     for (const fieldPermission of profile.fieldPermissions()) {
-      // Rule: "all fields should be editable"
-      // This is true for the most part, but some standard fields are a kind-of formula field that is mapped from another object.
-      // When you set <editable> to true for these, Salesforce just ignores it and sets them back to false.
-      // So only check the <editable> property for the supplied list of fields
+      // Only check field permissions for the supplied list of fields
+      // This restriction is in place for now, mainly because some standard fields can't be editable
       if (fieldNamesToCheck.includes(fieldPermission.objectFieldName)) {
         if (!fieldPermission.editable) {
           results.push(this.missingFieldPermissionWarning(profile, fieldPermission, 'editable'));
         }
-      }
-
-      // Rule: "all fields should be readable"
-      // Check <readable> property for ALL field permissions, regardless of what fields are supplied
-      if (!fieldPermission.readable) {
-        results.push(this.missingFieldPermissionWarning(profile, fieldPermission, 'readable'));
+        if (!fieldPermission.readable) {
+          results.push(this.missingFieldPermissionWarning(profile, fieldPermission, 'readable'));
+        }
       }
     }
 

--- a/src/ruleset/adminProfileRuleset.ts
+++ b/src/ruleset/adminProfileRuleset.ts
@@ -57,7 +57,8 @@ export class AdminProfileRuleset extends MetadataRuleset {
 
     for (const fieldPermission of profile.fieldPermissions()) {
       // Rule: "all fields should be editable"
-      // This is true for the most part, but some standard fields are a kind-of formula field that is mapped from another object
+      // This is true for the most part, but some standard fields are a kind-of formula field that is mapped from another object.
+      // When you set <editable> to true for these, Salesforce just ignores it and sets them back to false.
       // So only check the <editable> property for the supplied list of fields
       if (fieldNamesToCheck.includes(fieldPermission.objectFieldName)) {
         if (!fieldPermission.editable) {


### PR DESCRIPTION
"Quick fix" for the Admin Profile ruleset.

The 0.0.7 release introduced the Admin Profile ruleset. One of its checks was to ensure that **all** `<fieldPermissions>` needed to have `<editable>` set to `true`. However, there are fields that _cannot_ be editable, e.g. some fields on standard objects appear to fields that are just mapped from other objects. If you set editable to true on these fields, they will deploy successfully, but will just stay set to false (which you see when you force:source:retrieve the profile).

So this fix is the first step: dial back the checks over the `<editable>` property. Only enforce the rule that editable must be true for fields on custom objects. Not ideal, but better than nothing while I work to understand Salesforce's behaviour.