### PR TITLE
Extend admin profile ruleset to cover more object types

### DIFF
--- a/src/metadata_browser/customObject.ts
+++ b/src/metadata_browser/customObject.ts
@@ -19,6 +19,11 @@ export class CustomObject extends MetadataComponent {
     return this.customSettingsType !== undefined;
   }
 
+  public isStandardObject(): boolean {
+    // assumption: standard Salesforce objects don't have a double-underscore anywhere in their name
+    return !this.name.includes('__');
+  }
+
   private get customSettingsType(): string {
     return getString(this.metadata, 'customSettingsType');
   }

--- a/src/metadata_browser/customObject.ts
+++ b/src/metadata_browser/customObject.ts
@@ -8,6 +8,10 @@ export class CustomObject extends MetadataComponent {
   protected readonly fileExtension = 'object';
   protected readonly metadataType = 'CustomObject';
 
+  public isCustomMetadataType(): boolean {
+    return this.name.endsWith('__mdt');
+  }
+
   public isCustomObject(): boolean {
     // standard objects don't have a suffix, custom objects end with '__c'
     // custom settings also end in '__c' so we need to filter them out here
@@ -17,6 +21,10 @@ export class CustomObject extends MetadataComponent {
   public isCustomSetting(): boolean {
     // if the object's metadata has a <customSettingsType> field, then this is a custom settings object.
     return this.customSettingsType !== undefined;
+  }
+
+  public isExternalObject(): boolean {
+    return this.name.endsWith('__x');
   }
 
   public isStandardObject(): boolean {

--- a/src/metadata_browser/metadataComponent.ts
+++ b/src/metadata_browser/metadataComponent.ts
@@ -47,7 +47,18 @@ export abstract class MetadataComponent {
 
 // Abstract base class for sub-components of objects, e.g. fields, record types
 export abstract class ObjectSubComponent extends MetadataComponent {
+  private readonly objectNameOverride: string;
+
+  public constructor(fileName: string, objectNameOverride: string = null) {
+    super(fileName);
+    this.objectNameOverride = objectNameOverride;
+  }
+
   public get objectName(): string {
+    return this.objectNameOverride || this.originalObjectName;
+  }
+
+  public get originalObjectName(): string {
     const dir = path.dirname(this.fileName);
     const split = dir.split(path.sep); // assumes fileName is using the appropriate path separator for the platform
     return split[split.length - 2];

--- a/src/metadata_browser/sfdxProjectBrowser.test.ts
+++ b/src/metadata_browser/sfdxProjectBrowser.test.ts
@@ -6,7 +6,7 @@ import { SfdxProjectBrowser } from './sfdxProjectBrowser';
 
 describe('SfdxProjectBrowser', () => {
   describe('.lwcBundles()', () => {
-    it('should return an array of LightningComponentBundle objects; one for each subfolder', () => {
+    it('returns an array of LightningComponentBundle objects', () => {
       const sfdxProjectBrowser = new SfdxProjectBrowser(null);
       const mockProjectBrowser = sinon.mock(sfdxProjectBrowser);
       mockProjectBrowser.expects('lwcBaseDir').once().returns('src/test/metadata/lwc');
@@ -17,6 +17,20 @@ describe('SfdxProjectBrowser', () => {
       // other properties of LightningComponentBundle are tested elsewhere
       expect(results[0].baseFolder).to.equal(path.normalize('src/test/metadata/lwc/BadExample'));
       expect(results[1].baseFolder).to.equal(path.normalize('src/test/metadata/lwc/GoodExample'));
+      mockProjectBrowser.verify();
+    });
+  });
+
+  describe('.objects', () => {
+    it('returns an array of CustomObject objects', () => {
+      const sfdxProjectBrowser = new SfdxProjectBrowser(null);
+      const mockProjectBrowser = sinon.mock(sfdxProjectBrowser);
+      mockProjectBrowser.expects('objectsBaseDir').once().returns('src/test/metadata/objects');
+
+      const results = sfdxProjectBrowser.objects();
+      expect(results.length).to.equal(2);
+      expect(results[0].name).to.equal('TestObject1');
+      expect(results[1].name).to.equal('TestObject2');
       mockProjectBrowser.verify();
     });
   });

--- a/src/metadata_browser/sfdxProjectBrowser.ts
+++ b/src/metadata_browser/sfdxProjectBrowser.ts
@@ -98,7 +98,8 @@ export class SfdxProjectBrowser {
   }
 
   // Given a list of CustomObject objects, return the ones that are _actually_ considered to be objects for most purposes
-  // e.g. don't return Custom Settings, Custom Metadata and the like
+  // e.g. a custom metadata type is considered to be an object, but custom settings aren't
+  // These rules are fairly subjective & are largely driven by what appears in the <objectPermissions> section of a Profile
   private filterObjects(objects: CustomObject[]): CustomObject[] {
     return objects
       .filter(

--- a/src/metadata_browser/sfdxProjectBrowser.ts
+++ b/src/metadata_browser/sfdxProjectBrowser.ts
@@ -31,7 +31,11 @@ export class SfdxProjectBrowser {
       // These are likely to be packaged objects that have been modified in some way (e.g. a custom field was added).
       // TODO: Revisit this thinking. Is it valid for all scenarios?
       if (fs.existsSync(fileName)) {
-        results.push(new CustomObject(fileName));
+        const object = new CustomObject(fileName);
+
+        if (object.name !== 'Activity') {
+          results.push(object);
+        }
       }
     }
 
@@ -43,11 +47,8 @@ export class SfdxProjectBrowser {
     return new EmailToCaseSettings(fileName);
   }
 
-  // Return the list of fields for a given object
   public fields(objectName: string): CustomField[] {
-    const dir = this.customFieldsBaseDir(objectName);
-    const fileNames = fs.existsSync(dir) ? fs.readdirSync(dir) : [];
-    return fileNames.map((f) => new CustomField(path.join(dir, f)));
+    return this.fieldsForObject(objectName);
   }
 
   // Return a map of all LWCs. key = LWC name, value = full path to the folder that contains all the components for that LWC
@@ -83,6 +84,12 @@ export class SfdxProjectBrowser {
   // Directory containing fields for a given object
   private customFieldsBaseDir(objectName: string): string {
     return path.join(this.objectDir(objectName), 'fields');
+  }
+
+  private fieldsForObject(objectName: string, objectNameOverride: string = null): CustomField[] {
+    const dir = this.customFieldsBaseDir(objectName);
+    const fileNames = fs.existsSync(dir) ? fs.readdirSync(dir) : [];
+    return fileNames.map((f) => new CustomField(path.join(dir, f), objectNameOverride));
   }
 
   private lwcBaseDir(): string {

--- a/src/metadata_browser/sfdxProjectBrowser.ts
+++ b/src/metadata_browser/sfdxProjectBrowser.ts
@@ -101,7 +101,13 @@ export class SfdxProjectBrowser {
   // e.g. don't return Custom Settings, Custom Metadata and the like
   private filterObjects(objects: CustomObject[]): CustomObject[] {
     return objects
-      .filter((object) => object.isStandardObject() || object.isCustomObject())
+      .filter(
+        (object) =>
+          object.isStandardObject() ||
+          object.isCustomObject() ||
+          object.isCustomMetadataType() ||
+          object.isExternalObject()
+      )
       .filter((object) => !this.OBJECTS_TO_IGNORE.includes(object.name));
   }
 

--- a/src/metadata_browser/sfdxProjectBrowser.ts
+++ b/src/metadata_browser/sfdxProjectBrowser.ts
@@ -33,9 +33,18 @@ export class SfdxProjectBrowser {
       if (fs.existsSync(fileName)) {
         const object = new CustomObject(fileName);
 
-        if (object.name !== 'Activity') {
-          results.push(object);
+        // Not interested in Custom Settings here
+        if (object.isCustomSetting()) {
+          continue;
         }
+
+        // Don't return Activity in the list. It's not an object you can interact with directly in Salesforce.
+        // Instead you use it via the Event and Task objects (sort-of like a abstract parent / concrete child class relationship)
+        if (object.name === 'Activity') {
+          continue;
+        }
+
+        results.push(object);
       }
     }
 

--- a/src/metadata_browser/sfdxProjectBrowser.ts
+++ b/src/metadata_browser/sfdxProjectBrowser.ts
@@ -47,7 +47,12 @@ export class SfdxProjectBrowser {
     return new EmailToCaseSettings(fileName);
   }
 
+  // Return the list of fields for a given object
   public fields(objectName: string): CustomField[] {
+    if (objectName === 'Event' || objectName === 'Task') {
+      const fieldsFromActivityObject = this.fieldsForObject('Activity', objectName);
+      return this.fieldsForObject(objectName).concat(fieldsFromActivityObject);
+    }
     return this.fieldsForObject(objectName);
   }
 

--- a/src/ruleset/recordTypePicklistRuleset.ts
+++ b/src/ruleset/recordTypePicklistRuleset.ts
@@ -5,7 +5,7 @@ import { MetadataRuleset } from './metadataRuleset';
 export class RecordTypePicklistRuleset extends MetadataRuleset {
   public displayName = 'Record type picklists';
 
-  private IGNORE_OBJECTS = ['Event', 'PersonAccount', 'Task'];
+  private IGNORE_OBJECTS = ['PersonAccount'];
   private BONUS_EXPECTED_PICKLISTS = ['Name', 'ForecastCategoryName'];
 
   public run(): MetadataProblem[] {

--- a/src/ruleset/recordTypePicklistValueRuleset.ts
+++ b/src/ruleset/recordTypePicklistValueRuleset.ts
@@ -6,7 +6,7 @@ import { MetadataRuleset } from './metadataRuleset';
 export class RecordTypePicklistValueRuleset extends MetadataRuleset {
   public displayName = 'Record type picklist values';
 
-  private IGNORE_OBJECTS = ['Event', 'PersonAccount', 'Task'];
+  private IGNORE_OBJECTS = ['PersonAccount'];
   private IGNORE_PICKLISTS = ['ForecastCategoryName'];
 
   // Run the record type picklist value checks. Returns an array of warning messages.

--- a/src/test/metadata/objects/TestObject1/TestObject1.object-meta.xml
+++ b/src/test/metadata/objects/TestObject1/TestObject1.object-meta.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">
+</CustomObject>

--- a/src/test/metadata/objects/TestObject2/TestObject2.object-meta.xml
+++ b/src/test/metadata/objects/TestObject2/TestObject2.object-meta.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">
+</CustomObject>


### PR DESCRIPTION
### Overview
Extends the Admin profile ruleset, in particular the rules that ensure all fields (with caveats around what "all" means) should have full read/edit permissions in the Admin profile.

### Previous behaviour
Only checked fields on custom objects

### New behaviour
Now covers:
* all fields on custom objects (same as before)
* custom fields on standard objects
* all fields on custom metadata types (`__mdt`)
* all fields on external (`__x`) objects

Still _doesn't_ check standard fields - there are some rules around which ones should/shouldn't appear in profiles that I don't yet understand.

### Notes
It took a bit of refactoring to properly cover the **Event** and **Task** objects. These are "subclasses" of **Activity**, so any custom fields on Activity actually appear against Event and Task in profiles.

A happy side-effect of this refactoring is that the Record Type rulesets now work correctly for the Event and Task objects!