### PR TITLE
Don't require formula fields to be <editable> in Admin profile

### DIFF
--- a/src/metadata_browser/customField.test.ts
+++ b/src/metadata_browser/customField.test.ts
@@ -15,13 +15,28 @@ describe('CustomField', () => {
   });
 
   describe('.isCustom()', () => {
-    it('should return true for custom objects', () => {
+    it('should return true for custom fields', () => {
       const customField = new CustomField('FieldName__c');
       expect(customField.isCustom()).to.equal(true);
     });
-    it('should return false for standard objects', () => {
+    it('should return false for standard fields', () => {
       const customField = new CustomField('Account');
       expect(customField.isCustom()).to.equal(false);
+    });
+  });
+
+  describe('.isFormula()', () => {
+    it('should return true if there is a <formula> string in the metadata', () => {
+      const customField = new CustomField('');
+      const json: JsonMap = { formula: 'some_formula' };
+      sinon.stub(customField, 'metadata').get(() => json);
+      expect(customField.isFormula()).to.equal(true);
+    });
+    it('should return false otherwise', () => {
+      const customField = new CustomField('');
+      const json: JsonMap = {};
+      sinon.stub(customField, 'metadata').get(() => json);
+      expect(customField.isFormula()).to.equal(false);
     });
   });
 

--- a/src/metadata_browser/customField.ts
+++ b/src/metadata_browser/customField.ts
@@ -1,4 +1,4 @@
-import { getBoolean, getString } from '@salesforce/ts-types';
+import { getBoolean, getString, hasString } from '@salesforce/ts-types';
 import { ObjectSubComponent } from './metadataComponent';
 
 // Basic CustomField class
@@ -14,6 +14,10 @@ export class CustomField extends ObjectSubComponent {
 
   public isCustom(): boolean {
     return this.name.endsWith('__c');
+  }
+
+  public isFormula(): boolean {
+    return hasString(this.metadata, 'formula');
   }
 
   public isPicklist(): boolean {

--- a/src/ruleset/adminProfileRuleset.test.ts
+++ b/src/ruleset/adminProfileRuleset.test.ts
@@ -86,14 +86,16 @@ describe('AdminProfileRuleset', () => {
     context('when the field is one of the "fields to check"', () => {
       it('should return a warning when <editable> or <readable> are false', () => {
         const profile = new Profile('Admin.profile-meta.xml');
-        const fieldsToCheck = [new CustomField('objects/Object1/fields/Field1.field-meta.xml')];
+        const field = new CustomField('objects/Object1/fields/Field1.field-meta.xml');
+        sinon.stub(field, 'isFormula').returns(false);
+
         const fieldPermissions = [
           new ProfileFieldPermission({ editable: false, field: 'Object1.Field1', readable: false }),
         ];
         sinon.stub(profile, 'fieldPermissions').returns(fieldPermissions);
 
         const ruleset = new AdminProfileRuleset(null);
-        const results = ruleset['missingFieldPermissions'](profile, fieldsToCheck);
+        const results = ruleset['missingFieldPermissions'](profile, [field]);
         expect(results.length).to.equal(2);
         expect(results[0].componentName).to.equal('Admin');
         expect(results[0].componentType).to.equal('Profile');

--- a/src/ruleset/adminProfileRuleset.test.ts
+++ b/src/ruleset/adminProfileRuleset.test.ts
@@ -82,7 +82,7 @@ describe('AdminProfileRuleset', () => {
     });
   });
 
-  describe('.missingFieldPermissions()', () => {
+  describe('.fieldPermissionWarnings()', () => {
     context('when the field is one of the "fields to check"', () => {
       it('should return a warning when <editable> or <readable> are false', () => {
         const profile = new Profile('Admin.profile-meta.xml');
@@ -95,7 +95,7 @@ describe('AdminProfileRuleset', () => {
         sinon.stub(profile, 'fieldPermissions').returns(fieldPermissions);
 
         const ruleset = new AdminProfileRuleset(null);
-        const results = ruleset['missingFieldPermissions'](profile, [field]);
+        const results = ruleset['fieldPermissionWarnings'](profile, [field]);
         expect(results.length).to.equal(2);
         expect(results[0].componentName).to.equal('Admin');
         expect(results[0].componentType).to.equal('Profile');
@@ -117,7 +117,7 @@ describe('AdminProfileRuleset', () => {
         sinon.stub(profile, 'fieldPermissions').returns(fieldPermissions);
 
         const ruleset = new AdminProfileRuleset(null);
-        const results = ruleset['missingFieldPermissions'](profile, fieldsToCheck);
+        const results = ruleset['fieldPermissionWarnings'](profile, fieldsToCheck);
         expect(results.length).to.equal(0);
       });
     });
@@ -131,7 +131,7 @@ describe('AdminProfileRuleset', () => {
         sinon.stub(profile, 'fieldPermissions').returns(fieldPermissions);
 
         const ruleset = new AdminProfileRuleset(null);
-        const results = ruleset['missingFieldPermissions'](profile, fieldsToCheck);
+        const results = ruleset['fieldPermissionWarnings'](profile, fieldsToCheck);
         expect(results.length).to.equal(0);
       });
     });

--- a/src/ruleset/adminProfileRuleset.test.ts
+++ b/src/ruleset/adminProfileRuleset.test.ts
@@ -84,29 +84,57 @@ describe('AdminProfileRuleset', () => {
 
   describe('.fieldPermissionWarnings()', () => {
     context('when the field is one of the "fields to check"', () => {
-      it('should return a warning when <editable> or <readable> are false', () => {
+      it('should return a warning when <editable> is false', () => {
         const profile = new Profile('Admin.profile-meta.xml');
-        const field = new CustomField('objects/Object1/fields/Field1.field-meta.xml');
+        const field = new CustomField('objects/Object1/fields/Field1__c.field-meta.xml');
         sinon.stub(field, 'isFormula').returns(false);
 
         const fieldPermissions = [
-          new ProfileFieldPermission({ editable: false, field: 'Object1.Field1', readable: false }),
+          new ProfileFieldPermission({ editable: false, field: 'Object1.Field1__c', readable: true }),
         ];
         sinon.stub(profile, 'fieldPermissions').returns(fieldPermissions);
 
         const ruleset = new AdminProfileRuleset(null);
         const results = ruleset['fieldPermissionWarnings'](profile, [field]);
-        expect(results.length).to.equal(2);
+        expect(results.length).to.equal(1);
         expect(results[0].componentName).to.equal('Admin');
         expect(results[0].componentType).to.equal('Profile');
         expect(results[0].fileName).to.equal('Admin.profile-meta.xml');
-        expect(results[0].problem).to.equal('<editable> permission not set for field Object1.Field1');
+        expect(results[0].problem).to.equal('<editable> permission not set for field Object1.Field1__c');
         expect(results[0].problemType).to.equal('Warning');
-        expect(results[1].componentName).to.equal('Admin');
-        expect(results[1].componentType).to.equal('Profile');
-        expect(results[1].fileName).to.equal('Admin.profile-meta.xml');
-        expect(results[1].problem).to.equal('<readable> permission not set for field Object1.Field1');
-        expect(results[1].problemType).to.equal('Warning');
+      });
+      it('should not return a warning when <editable> is false, but the field is a formula field', () => {
+        const profile = new Profile('Admin.profile-meta.xml');
+        const field = new CustomField('objects/Object1/fields/Field1__c.field-meta.xml');
+        sinon.stub(field, 'isFormula').returns(true);
+
+        const fieldPermissions = [
+          new ProfileFieldPermission({ editable: false, field: 'Object1.Field1__c', readable: true }),
+        ];
+        sinon.stub(profile, 'fieldPermissions').returns(fieldPermissions);
+
+        const ruleset = new AdminProfileRuleset(null);
+        const results = ruleset['fieldPermissionWarnings'](profile, [field]);
+        expect(results.length).to.equal(0);
+      });
+      it('should return a warning when <readable> is false', () => {
+        const profile = new Profile('Admin.profile-meta.xml');
+        const field = new CustomField('objects/Object1/fields/Field1.field-meta.xml');
+        sinon.stub(field, 'isFormula').returns(false);
+
+        const fieldPermissions = [
+          new ProfileFieldPermission({ editable: true, field: 'Object1.Field1', readable: false }),
+        ];
+        sinon.stub(profile, 'fieldPermissions').returns(fieldPermissions);
+
+        const ruleset = new AdminProfileRuleset(null);
+        const results = ruleset['fieldPermissionWarnings'](profile, [field]);
+        expect(results.length).to.equal(1);
+        expect(results[0].componentName).to.equal('Admin');
+        expect(results[0].componentType).to.equal('Profile');
+        expect(results[0].fileName).to.equal('Admin.profile-meta.xml');
+        expect(results[0].problem).to.equal('<readable> permission not set for field Object1.Field1');
+        expect(results[0].problemType).to.equal('Warning');
       });
       it('should not return a warning when <editable> and <readable> are true', () => {
         const profile = new Profile('Admin.profile-meta.xml');
@@ -122,7 +150,7 @@ describe('AdminProfileRuleset', () => {
       });
     });
     context('when the field is *not* one of the "fields to check"', () => {
-      it('should not check the field and not return a warning', () => {
+      it('should not check the field and should not return a warning', () => {
         const profile = new Profile('Admin.profile-meta.xml');
         const fieldsToCheck = [];
         // No editable or readable property here on purpose


### PR DESCRIPTION
Closes issue #52

The Admin Profile ruleset requires all custom fields to be `<editable>` in the Admin profile. However, this is not relevant for *formula* fields, which _can't_ be editable.

In such cases, Salesforce doesn't seem to mind whether `<editable>` is true or false. Deployments will work regardless. This adjusts the ruleset behaviour to match Salesforce.