### PR TITLE
Minimum access profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ An optional `.dxcoprc` configuration file, in JSON format, can be used to enable
         "adminProfile": { "enabled": false },
         "emailToCaseSettings": { "enabled": true },
         "lightningWebComponents": { "enabled": true },
+        "minimumAccessProfile": { "enabled": false, "profileName": "Minimum Access - Salesforce" },
         "recordTypePicklists": { "enabled": true },
         "recordTypePicklistValues": { "enabled": true }
     }
@@ -76,6 +77,12 @@ Also ensures that `<routingAddresses>` are ordered by `<routingName>`.
 ### Lightning web components
 
 Checks `*.js-meta.xml` files for extra whitespace at the ends of lines. This can cause unexpected behaviour when you retrieve the same component after deployment; extra lines of whitespace can be inserted resulting in unexpected file differences.
+
+### Minimum Access profile
+
+The Minimum Access profile should not have access (read, edit, delete, etc) to _any_ objects or fields. Access should be controlled via permission sets instead. This ruleset will raise a warning if any `<fieldPermissions>` or `<objectPermissions>` elements in the Minimum Access profile are true.
+
+By default the "Minimum Access - Salesforce" profile will be examined. This can be changed in the config file.
 
 ### Record types: picklist names
 

--- a/src/commands/dxcop/source/check.ts
+++ b/src/commands/dxcop/source/check.ts
@@ -12,6 +12,7 @@ import { EmailToCaseSettingsRuleset } from '../../../ruleset/emailToCaseSettings
 import { LwcMetadataRuleset } from '../../../ruleset/lwcMetadataRuleset';
 import { MetadataProblem } from '../../../ruleset/metadataProblem';
 import { MetadataRuleset } from '../../../ruleset/metadataRuleset';
+import { MinimumAccessProfileRuleset } from '../../../ruleset/minimumAccessProfileRuleset';
 import { RecordTypePicklistRuleset } from '../../../ruleset/recordTypePicklistRuleset';
 import { RecordTypePicklistValueRuleset } from '../../../ruleset/recordTypePicklistValueRuleset';
 
@@ -74,6 +75,9 @@ export default class Check extends SfdxCommand {
     }
     if (config.ruleSets.lightningWebComponents.enabled) {
       rulesets.push(new LwcMetadataRuleset(sfdxProjectBrowser));
+    }
+    if (config.ruleSets.minimumAccessProfile.enabled) {
+      rulesets.push(new MinimumAccessProfileRuleset(sfdxProjectBrowser));
     }
     if (config.ruleSets.recordTypePicklists.enabled) {
       rulesets.push(new RecordTypePicklistRuleset(sfdxProjectBrowser));

--- a/src/commands/dxcop/source/check.ts
+++ b/src/commands/dxcop/source/check.ts
@@ -77,7 +77,9 @@ export default class Check extends SfdxCommand {
       rulesets.push(new LwcMetadataRuleset(sfdxProjectBrowser));
     }
     if (config.ruleSets.minimumAccessProfile.enabled) {
-      rulesets.push(new MinimumAccessProfileRuleset(sfdxProjectBrowser));
+      rulesets.push(
+        new MinimumAccessProfileRuleset(sfdxProjectBrowser, config.ruleSets.minimumAccessProfile.profileName)
+      );
     }
     if (config.ruleSets.recordTypePicklists.enabled) {
       rulesets.push(new RecordTypePicklistRuleset(sfdxProjectBrowser));

--- a/src/config/defaultConfig.ts
+++ b/src/config/defaultConfig.ts
@@ -7,7 +7,7 @@ export default function defaultConfig() {
       adminProfile: { enabled: false },
       emailToCaseSettings: { enabled: true },
       lightningWebComponents: { enabled: true },
-      minimumAccessProfile: { enabled: false },
+      minimumAccessProfile: { enabled: false, profileName: 'Minimum Access - Salesforce' },
       recordTypePicklists: { enabled: true },
       recordTypePicklistValues: { enabled: true },
     },

--- a/src/config/defaultConfig.ts
+++ b/src/config/defaultConfig.ts
@@ -7,6 +7,7 @@ export default function defaultConfig() {
       adminProfile: { enabled: false },
       emailToCaseSettings: { enabled: true },
       lightningWebComponents: { enabled: true },
+      minimumAccessProfile: { enabled: false },
       recordTypePicklists: { enabled: true },
       recordTypePicklistValues: { enabled: true },
     },

--- a/src/metadata_browser/profile.test.ts
+++ b/src/metadata_browser/profile.test.ts
@@ -44,7 +44,7 @@ describe('Profile', () => {
 
 describe('ProfileFieldPermission', () => {
   it('should return correct values for all properties', () => {
-    const fieldPerm = new ProfileFieldPermission({
+    const fieldPerm = new ProfileFieldPermission(null, {
       editable: false,
       field: 'TestObject.TestField__c',
       readable: true,
@@ -54,18 +54,18 @@ describe('ProfileFieldPermission', () => {
     expect(fieldPerm.readable).to.equal(true, 'readable');
   });
   it('should derive the object name from the composite object/field property', () => {
-    const fieldPerm = new ProfileFieldPermission({ field: 'ObjectName.FieldName' });
+    const fieldPerm = new ProfileFieldPermission(null, { field: 'ObjectName.FieldName' });
     expect(fieldPerm.objectName()).to.equal('ObjectName');
   });
   it('should derive the field name from the composite object/field property', () => {
-    const fieldPerm = new ProfileFieldPermission({ field: 'ObjectName.FieldName' });
+    const fieldPerm = new ProfileFieldPermission(null, { field: 'ObjectName.FieldName' });
     expect(fieldPerm.fieldName()).to.equal('FieldName');
   });
 });
 
 describe('ProfileObjectPermission', () => {
   it('should return correct values for all properties', () => {
-    const objPerm = new ProfileObjectPermission({
+    const objPerm = new ProfileObjectPermission(null, {
       allowCreate: false,
       allowDelete: false,
       allowEdit: true,

--- a/src/metadata_browser/profile.test.ts
+++ b/src/metadata_browser/profile.test.ts
@@ -1,43 +1,66 @@
 import 'mocha';
 import { expect } from 'chai';
 import * as sinon from 'sinon';
-import { JsonMap } from '@salesforce/ts-types';
 import { Profile, ProfileFieldPermission, ProfileObjectPermission } from './profile';
 
 describe('Profile', () => {
+  const profile = new Profile('');
+
   describe('.fieldPermissions()', () => {
     it('should return an array of ProfileFieldPermission objects', () => {
-      const json: JsonMap = {
+      const metadata = {
         fieldPermissions: [
           { editable: false, field: 'TestObject.Field1__c', readable: true },
           { editable: false, field: 'TestObject.Field2__c', readable: true },
         ],
       };
-      const profile = new Profile('');
-      sinon.stub(profile, 'metadata').get(() => json);
-
+      sinon.stub(profile, 'metadata').get(() => metadata);
       const results = profile.fieldPermissions();
       expect(results.length).to.equal(2);
       expect(results[0].objectFieldName).to.equal('TestObject.Field1__c');
       expect(results[1].objectFieldName).to.equal('TestObject.Field2__c');
     });
+
+    it('should return an array containing a single ProfileFieldPermission object', () => {
+      const metadata = { fieldPermissions: { editable: false, readable: true, field: 'TestObject.Field1__c' } };
+      sinon.stub(profile, 'metadata').get(() => metadata);
+      expect(profile.fieldPermissions().length).to.equal(1);
+      expect(profile.fieldPermissions()[0].objectFieldName).to.equal('TestObject.Field1__c');
+    });
+
+    it('should return an empty array', () => {
+      const metadata = {};
+      sinon.stub(profile, 'metadata').get(() => metadata);
+      expect(profile.fieldPermissions().length).to.equal(0);
+    });
   });
 
   describe('.objectPermissions()', () => {
     it('should return an array of ProfileObjectPermission objects', () => {
-      const json: JsonMap = {
+      const metadata = {
         objectPermissions: [
           { allowEdit: false, allowRead: true, object: 'TestObject1__c' },
           { allowEdit: false, allowRead: true, object: 'TestObject2__c' },
         ],
       };
-      const profile = new Profile('');
-      sinon.stub(profile, 'metadata').get(() => json);
-
+      sinon.stub(profile, 'metadata').get(() => metadata);
       const results = profile.objectPermissions();
       expect(results.length).to.equal(2);
       expect(results[0].objectName).to.equal('TestObject1__c');
       expect(results[1].objectName).to.equal('TestObject2__c');
+    });
+
+    it('should return an array containing a single ProfileObjectPermission object', () => {
+      const metadata = { objectPermissions: { allowEdit: false, allowRead: true, object: 'Object1__c' } };
+      sinon.stub(profile, 'metadata').get(() => metadata);
+      expect(profile.objectPermissions().length).to.equal(1);
+      expect(profile.objectPermissions()[0].objectName).to.equal('Object1__c');
+    });
+
+    it('should return an empty array', () => {
+      const metadata = {};
+      sinon.stub(profile, 'metadata').get(() => metadata);
+      expect(profile.objectPermissions().length).to.equal(0);
     });
   });
 });

--- a/src/metadata_browser/profile.ts
+++ b/src/metadata_browser/profile.ts
@@ -7,12 +7,12 @@ export class Profile extends MetadataComponent {
 
   public fieldPermissions(): ProfileFieldPermission[] {
     const permissions = getJsonArray(this.metadata, 'fieldPermissions');
-    return permissions.map((p) => new ProfileFieldPermission(p));
+    return permissions.map((p) => new ProfileFieldPermission(this, p));
   }
 
   public objectPermissions(): ProfileObjectPermission[] {
     const permissions = getJsonArray(this.metadata, 'objectPermissions');
-    return permissions.map((p) => new ProfileObjectPermission(p));
+    return permissions.map((op) => new ProfileObjectPermission(this, op));
   }
 }
 
@@ -24,9 +24,11 @@ export class Profile extends MetadataComponent {
 // </fieldPermissions>
 // --> converted to JSON this would look like { editable: false, field: 'Account.AccountNumber', readable: true }
 export class ProfileFieldPermission {
+  public readonly profile: Profile;
   private readonly json: AnyJson;
 
-  public constructor(json: AnyJson) {
+  public constructor(profile: Profile, json: AnyJson) {
+    this.profile = profile;
     this.json = json;
   }
 
@@ -63,9 +65,11 @@ export class ProfileFieldPermission {
 // </objectPermissions>
 // --> converted to JSON this would look like { allowCreate: true, allowDelete: true, ... }
 export class ProfileObjectPermission {
+  public readonly profile: Profile;
   private readonly json: AnyJson;
 
-  public constructor(json: AnyJson) {
+  public constructor(profile: Profile, json: AnyJson) {
+    this.profile = profile;
     this.json = json;
   }
 

--- a/src/metadata_browser/profile.ts
+++ b/src/metadata_browser/profile.ts
@@ -1,4 +1,12 @@
-import { AnyJson, getBoolean, getJsonArray, getString } from '@salesforce/ts-types';
+import {
+  AnyJson,
+  getBoolean,
+  getJsonArray,
+  getJsonMap,
+  getString,
+  hasJsonArray,
+  hasJsonMap,
+} from '@salesforce/ts-types';
 import { MetadataComponent } from './metadataComponent';
 
 export class Profile extends MetadataComponent {
@@ -6,13 +14,29 @@ export class Profile extends MetadataComponent {
   protected readonly metadataType = 'Profile';
 
   public fieldPermissions(): ProfileFieldPermission[] {
-    const permissions = getJsonArray(this.metadata, 'fieldPermissions');
-    return permissions.map((p) => new ProfileFieldPermission(this, p));
+    if (hasJsonArray(this.metadata, 'fieldPermissions')) {
+      const permissions = getJsonArray(this.metadata, 'fieldPermissions');
+      return permissions.map((p) => new ProfileFieldPermission(this, p));
+    } else if (hasJsonMap(this.metadata, 'fieldPermissions')) {
+      const permissionsMap = getJsonMap(this.metadata, 'fieldPermissions');
+      const permissions = new ProfileFieldPermission(this, permissionsMap);
+      return [permissions];
+    } else {
+      return [];
+    }
   }
 
   public objectPermissions(): ProfileObjectPermission[] {
-    const permissions = getJsonArray(this.metadata, 'objectPermissions');
-    return permissions.map((op) => new ProfileObjectPermission(this, op));
+    if (hasJsonArray(this.metadata, 'objectPermissions')) {
+      const permissions = getJsonArray(this.metadata, 'objectPermissions');
+      return permissions.map((op) => new ProfileObjectPermission(this, op));
+    } else if (hasJsonMap(this.metadata, 'objectPermissions')) {
+      const permissionsMap = getJsonMap(this.metadata, 'objectPermissions');
+      const permissions = new ProfileObjectPermission(this, permissionsMap);
+      return [permissions];
+    } else {
+      return [];
+    }
   }
 }
 

--- a/src/ruleset/adminProfileRuleset.test.ts
+++ b/src/ruleset/adminProfileRuleset.test.ts
@@ -60,8 +60,8 @@ describe('AdminProfileRuleset', () => {
     it("should return a list of warnings for fields that are expected to exist in the profile, but don't", () => {
       const profile = new Profile('Admin.profile-meta.xml');
       const fieldPermissions = [
-        new ProfileFieldPermission({ field: 'Object1.Field1' }),
-        new ProfileFieldPermission({ field: 'Object1.Field2' }),
+        new ProfileFieldPermission(profile, { field: 'Object1.Field1' }),
+        new ProfileFieldPermission(profile, { field: 'Object1.Field2' }),
       ];
       sinon.stub(profile, 'fieldPermissions').returns(fieldPermissions);
 
@@ -90,7 +90,7 @@ describe('AdminProfileRuleset', () => {
         sinon.stub(field, 'isFormula').returns(false);
 
         const fieldPermissions = [
-          new ProfileFieldPermission({ editable: false, field: 'Object1.Field1__c', readable: true }),
+          new ProfileFieldPermission(profile, { editable: false, field: 'Object1.Field1__c', readable: true }),
         ];
         sinon.stub(profile, 'fieldPermissions').returns(fieldPermissions);
 
@@ -109,7 +109,7 @@ describe('AdminProfileRuleset', () => {
         sinon.stub(field, 'isFormula').returns(true);
 
         const fieldPermissions = [
-          new ProfileFieldPermission({ editable: false, field: 'Object1.Field1__c', readable: true }),
+          new ProfileFieldPermission(profile, { editable: false, field: 'Object1.Field1__c', readable: true }),
         ];
         sinon.stub(profile, 'fieldPermissions').returns(fieldPermissions);
 
@@ -123,7 +123,7 @@ describe('AdminProfileRuleset', () => {
         sinon.stub(field, 'isFormula').returns(false);
 
         const fieldPermissions = [
-          new ProfileFieldPermission({ editable: true, field: 'Object1.Field1', readable: false }),
+          new ProfileFieldPermission(profile, { editable: true, field: 'Object1.Field1', readable: false }),
         ];
         sinon.stub(profile, 'fieldPermissions').returns(fieldPermissions);
 
@@ -140,7 +140,7 @@ describe('AdminProfileRuleset', () => {
         const profile = new Profile('Admin.profile-meta.xml');
         const fieldsToCheck = [new CustomField('objects/Object1/fields/Field1.field-meta.xml')];
         const fieldPermissions = [
-          new ProfileFieldPermission({ editable: true, field: 'Object1.Field1', readable: true }),
+          new ProfileFieldPermission(profile, { editable: true, field: 'Object1.Field1', readable: true }),
         ];
         sinon.stub(profile, 'fieldPermissions').returns(fieldPermissions);
 
@@ -155,7 +155,7 @@ describe('AdminProfileRuleset', () => {
         const fieldsToCheck = [];
         // No editable or readable property here on purpose
         // If the method's code tries to access either of these properties an error will occur
-        const fieldPermissions = [new ProfileFieldPermission({ field: 'Object1.Field1' })];
+        const fieldPermissions = [new ProfileFieldPermission(profile, { field: 'Object1.Field1' })];
         sinon.stub(profile, 'fieldPermissions').returns(fieldPermissions);
 
         const ruleset = new AdminProfileRuleset(null);
@@ -169,9 +169,9 @@ describe('AdminProfileRuleset', () => {
     it("should return a list of warnings for field permissions that aren't sorted by object/field name", () => {
       const profile = new Profile('Admin.profile-meta.xml');
       const fieldPermissions = [
-        new ProfileFieldPermission({ field: 'Object1.Field2' }),
-        new ProfileFieldPermission({ field: 'Object1.Field3' }),
-        new ProfileFieldPermission({ field: 'Object1.Field1' }),
+        new ProfileFieldPermission(profile, { field: 'Object1.Field2' }),
+        new ProfileFieldPermission(profile, { field: 'Object1.Field3' }),
+        new ProfileFieldPermission(profile, { field: 'Object1.Field1' }),
       ];
       sinon.stub(profile, 'fieldPermissions').returns(fieldPermissions);
 
@@ -190,7 +190,7 @@ describe('AdminProfileRuleset', () => {
   describe('.missingObjects()', () => {
     it("should return a list of warnings for objects that are expected to exist in the profile, but don't", () => {
       const profile = new Profile('Admin.profile-meta.xml');
-      const objectPermissions = [new ProfileObjectPermission({ object: 'Object1' })];
+      const objectPermissions = [new ProfileObjectPermission(profile, { object: 'Object1' })];
       sinon.stub(profile, 'objectPermissions').returns(objectPermissions);
 
       const expectedObjects = [
@@ -213,7 +213,7 @@ describe('AdminProfileRuleset', () => {
     it('should return a list of warnings for object permissions that are false, but should be true', () => {
       const profile = new Profile('Admin.profile-meta.xml');
       const objectPermissions = [
-        new ProfileObjectPermission({
+        new ProfileObjectPermission(profile, {
           allowCreate: false,
           allowDelete: false,
           allowEdit: false,
@@ -247,9 +247,9 @@ describe('AdminProfileRuleset', () => {
     it("should return a list of warnings for object permissions that aren't sorted by object", () => {
       const profile = new Profile('Admin.profile-meta.xml');
       const objectPermissions = [
-        new ProfileObjectPermission({ object: 'Object1' }),
-        new ProfileObjectPermission({ object: 'Object5' }),
-        new ProfileObjectPermission({ object: 'Object4' }),
+        new ProfileObjectPermission(profile, { object: 'Object1' }),
+        new ProfileObjectPermission(profile, { object: 'Object5' }),
+        new ProfileObjectPermission(profile, { object: 'Object4' }),
       ];
       sinon.stub(profile, 'objectPermissions').returns(objectPermissions);
 

--- a/src/ruleset/minimumAccessProfileRuleset.test.ts
+++ b/src/ruleset/minimumAccessProfileRuleset.test.ts
@@ -1,14 +1,15 @@
 import 'mocha';
 import { expect } from 'chai';
-import { Profile, ProfileFieldPermission } from '../metadata_browser/profile';
+import { Profile, ProfileFieldPermission, ProfileObjectPermission } from '../metadata_browser/profile';
 import { MinimumAccessProfileRuleset } from './minimumAccessProfileRuleset';
 
 describe('MinimumAccessProfileRuleset', () => {
+  const profile = new Profile('MinimumAccess.profile-meta.xml');
+  const ruleset = new MinimumAccessProfileRuleset(null);
+
   describe('.fieldPermissionWarnings()', () => {
-    it('returns a warning when a field is editable', () => {
-      const profile = new Profile('MinimumAccess.profile-meta.xml');
+    it('should return a warning when a field is editable', () => {
       const fieldPermission = new ProfileFieldPermission(profile, { field: 'Object1.Field1', editable: true });
-      const ruleset = new MinimumAccessProfileRuleset(null);
       const results = ruleset['fieldPermissionWarnings'](fieldPermission);
       expect(results.length).to.equal(1);
       expect(results[0].componentName).to.equal('MinimumAccess');
@@ -16,6 +17,77 @@ describe('MinimumAccessProfileRuleset', () => {
       expect(results[0].fileName).to.equal('MinimumAccess.profile-meta.xml');
       expect(results[0].problem).to.equal('<editable> permission should not be true for Object1.Field1 field');
       expect(results[0].problemType).to.equal('Warning');
+    });
+    it('should return a warning when a field is readable', () => {
+      const fieldPermission = new ProfileFieldPermission(profile, { field: 'Object1.Field1', readable: true });
+      const results = ruleset['fieldPermissionWarnings'](fieldPermission);
+      expect(results.length).to.equal(1);
+      expect(results[0].problem).to.equal('<readable> permission should not be true for Object1.Field1 field');
+    });
+    it('should not return any warnings when field permissions are all false', () => {
+      const fieldPermission = new ProfileFieldPermission(profile, {
+        field: 'Object1.Field1',
+        editable: false,
+        readable: false,
+      });
+      const results = ruleset['fieldPermissionWarnings'](fieldPermission);
+      expect(results.length).to.equal(0);
+    });
+
+    describe('.objectPermissionWarnings()', () => {
+      it('should return a warning when allowCreate is true', () => {
+        const objectPermission = new ProfileObjectPermission(profile, { object: 'Object1', allowCreate: true });
+        const results = ruleset['objectPermissionWarnings'](objectPermission);
+        expect(results.length).to.equal(1);
+        expect(results[0].componentName).to.equal('MinimumAccess');
+        expect(results[0].componentType).to.equal('Profile');
+        expect(results[0].fileName).to.equal('MinimumAccess.profile-meta.xml');
+        expect(results[0].problem).to.equal('<allowCreate> permission should not be true for Object1 object');
+        expect(results[0].problemType).to.equal('Warning');
+      });
+      it('should return a warning when allowDelete is true', () => {
+        const objectPermission = new ProfileObjectPermission(profile, { object: 'Object1', allowDelete: true });
+        const results = ruleset['objectPermissionWarnings'](objectPermission);
+        expect(results.length).to.equal(1);
+        expect(results[0].problem).to.equal('<allowDelete> permission should not be true for Object1 object');
+      });
+      it('should return a warning when allowEdit is true', () => {
+        const objectPermission = new ProfileObjectPermission(profile, { object: 'Object1', allowEdit: true });
+        const results = ruleset['objectPermissionWarnings'](objectPermission);
+        expect(results.length).to.equal(1);
+        expect(results[0].problem).to.equal('<allowEdit> permission should not be true for Object1 object');
+      });
+      it('should return a warning when allowRead is true', () => {
+        const objectPermission = new ProfileObjectPermission(profile, { object: 'Object1', allowRead: true });
+        const results = ruleset['objectPermissionWarnings'](objectPermission);
+        expect(results.length).to.equal(1);
+        expect(results[0].problem).to.equal('<allowRead> permission should not be true for Object1 object');
+      });
+      it('should return a warning when modifyAllRecords is true', () => {
+        const objectPermission = new ProfileObjectPermission(profile, { object: 'Object1', modifyAllRecords: true });
+        const results = ruleset['objectPermissionWarnings'](objectPermission);
+        expect(results.length).to.equal(1);
+        expect(results[0].problem).to.equal('<modifyAllRecords> permission should not be true for Object1 object');
+      });
+      it('should return a warning when viewAllRecords is true', () => {
+        const objectPermission = new ProfileObjectPermission(profile, { object: 'Object1', viewAllRecords: true });
+        const results = ruleset['objectPermissionWarnings'](objectPermission);
+        expect(results.length).to.equal(1);
+        expect(results[0].problem).to.equal('<viewAllRecords> permission should not be true for Object1 object');
+      });
+      it('should not return any warnings when all object permissions are false', () => {
+        const objectPermission = new ProfileObjectPermission(profile, {
+          field: 'Object1',
+          allowCreate: false,
+          allowDelete: false,
+          allowEdit: false,
+          allowRead: false,
+          modifyAllRecords: false,
+          viewAllRecords: false,
+        });
+        const results = ruleset['objectPermissionWarnings'](objectPermission);
+        expect(results.length).to.equal(0);
+      });
     });
   });
 });

--- a/src/ruleset/minimumAccessProfileRuleset.test.ts
+++ b/src/ruleset/minimumAccessProfileRuleset.test.ts
@@ -32,7 +32,7 @@ describe('MinimumAccessProfileRuleset', () => {
       expect(results[0].componentName).to.equal('MinimumAccess');
       expect(results[0].componentType).to.equal('Profile');
       expect(results[0].fileName).to.equal('MinimumAccess.profile-meta.xml');
-      expect(results[0].problem).to.equal('<editable> permission should not be true for Object1.Field1 field');
+      expect(results[0].problem).to.equal('<editable> permission should not be true for Object1.Field1');
       expect(results[0].problemType).to.equal('Warning');
     });
 
@@ -40,7 +40,7 @@ describe('MinimumAccessProfileRuleset', () => {
       const fieldPermission = new ProfileFieldPermission(profile, { field: 'Object1.Field1', readable: true });
       const results = ruleset['fieldPermissionWarnings'](fieldPermission);
       expect(results.length).to.equal(1);
-      expect(results[0].problem).to.equal('<readable> permission should not be true for Object1.Field1 field');
+      expect(results[0].problem).to.equal('<readable> permission should not be true for Object1.Field1');
     });
 
     it('should not return any warnings when all field permissions are false', () => {

--- a/src/ruleset/minimumAccessProfileRuleset.test.ts
+++ b/src/ruleset/minimumAccessProfileRuleset.test.ts
@@ -6,7 +6,7 @@ import { MinimumAccessProfileRuleset } from './minimumAccessProfileRuleset';
 
 describe('MinimumAccessProfileRuleset', () => {
   const profile = new Profile('MinimumAccess.profile-meta.xml');
-  const ruleset = new MinimumAccessProfileRuleset(null);
+  const ruleset = new MinimumAccessProfileRuleset(null, null);
 
   describe('.checkProfile()', () => {
     it('combines all warnings into a single list', () => {

--- a/src/ruleset/minimumAccessProfileRuleset.test.ts
+++ b/src/ruleset/minimumAccessProfileRuleset.test.ts
@@ -1,11 +1,28 @@
 import 'mocha';
 import { expect } from 'chai';
+import sinon = require('sinon');
 import { Profile, ProfileFieldPermission, ProfileObjectPermission } from '../metadata_browser/profile';
 import { MinimumAccessProfileRuleset } from './minimumAccessProfileRuleset';
 
 describe('MinimumAccessProfileRuleset', () => {
   const profile = new Profile('MinimumAccess.profile-meta.xml');
   const ruleset = new MinimumAccessProfileRuleset(null);
+
+  describe('.checkProfile()', () => {
+    it('combines all warnings into a single list', () => {
+      const profileMetadata = {
+        fieldPermissions: [
+          { editable: false, field: 'Object1.Field1', readable: true }, // 1 warning here
+          { editable: true, field: 'Object1.Field2', readable: true }, // 2 warnings here
+        ],
+        objectPermissions: [{ allowRead: true, object: 'Object1' }], // 1 warning here
+      };
+      sinon.stub(profile, 'metadata').get(() => profileMetadata);
+
+      const results = ruleset['checkProfile'](profile);
+      expect(results.length).to.equal(4);
+    });
+  });
 
   describe('.fieldPermissionWarnings()', () => {
     it('should return a warning when a field is editable', () => {
@@ -18,13 +35,15 @@ describe('MinimumAccessProfileRuleset', () => {
       expect(results[0].problem).to.equal('<editable> permission should not be true for Object1.Field1 field');
       expect(results[0].problemType).to.equal('Warning');
     });
+
     it('should return a warning when a field is readable', () => {
       const fieldPermission = new ProfileFieldPermission(profile, { field: 'Object1.Field1', readable: true });
       const results = ruleset['fieldPermissionWarnings'](fieldPermission);
       expect(results.length).to.equal(1);
       expect(results[0].problem).to.equal('<readable> permission should not be true for Object1.Field1 field');
     });
-    it('should not return any warnings when field permissions are all false', () => {
+
+    it('should not return any warnings when all field permissions are false', () => {
       const fieldPermission = new ProfileFieldPermission(profile, {
         field: 'Object1.Field1',
         editable: false,
@@ -33,61 +52,65 @@ describe('MinimumAccessProfileRuleset', () => {
       const results = ruleset['fieldPermissionWarnings'](fieldPermission);
       expect(results.length).to.equal(0);
     });
+  });
 
-    describe('.objectPermissionWarnings()', () => {
-      it('should return a warning when allowCreate is true', () => {
-        const objectPermission = new ProfileObjectPermission(profile, { object: 'Object1', allowCreate: true });
-        const results = ruleset['objectPermissionWarnings'](objectPermission);
-        expect(results.length).to.equal(1);
-        expect(results[0].componentName).to.equal('MinimumAccess');
-        expect(results[0].componentType).to.equal('Profile');
-        expect(results[0].fileName).to.equal('MinimumAccess.profile-meta.xml');
-        expect(results[0].problem).to.equal('<allowCreate> permission should not be true for Object1 object');
-        expect(results[0].problemType).to.equal('Warning');
+  describe('.objectPermissionWarnings()', () => {
+    it('should return a warning when allowCreate is true', () => {
+      const objectPermission = new ProfileObjectPermission(profile, { object: 'Object1', allowCreate: true });
+      const results = ruleset['objectPermissionWarnings'](objectPermission);
+      expect(results.length).to.equal(1);
+      expect(results[0].componentName).to.equal('MinimumAccess');
+      expect(results[0].componentType).to.equal('Profile');
+      expect(results[0].fileName).to.equal('MinimumAccess.profile-meta.xml');
+      expect(results[0].problem).to.equal('<allowCreate> permission should not be true for Object1 object');
+      expect(results[0].problemType).to.equal('Warning');
+    });
+
+    it('should return a warning when allowDelete is true', () => {
+      const objectPermission = new ProfileObjectPermission(profile, { object: 'Object1', allowDelete: true });
+      const results = ruleset['objectPermissionWarnings'](objectPermission);
+      expect(results.length).to.equal(1);
+      expect(results[0].problem).to.equal('<allowDelete> permission should not be true for Object1 object');
+    });
+
+    it('should return a warning when allowEdit is true', () => {
+      const objectPermission = new ProfileObjectPermission(profile, { object: 'Object1', allowEdit: true });
+      const results = ruleset['objectPermissionWarnings'](objectPermission);
+      expect(results.length).to.equal(1);
+      expect(results[0].problem).to.equal('<allowEdit> permission should not be true for Object1 object');
+    });
+
+    it('should return a warning when allowRead is true', () => {
+      const objectPermission = new ProfileObjectPermission(profile, { object: 'Object1', allowRead: true });
+      const results = ruleset['objectPermissionWarnings'](objectPermission);
+      expect(results.length).to.equal(1);
+      expect(results[0].problem).to.equal('<allowRead> permission should not be true for Object1 object');
+    });
+
+    it('should return a warning when modifyAllRecords or viewAllRecords is true', () => {
+      const objectPermission = new ProfileObjectPermission(profile, {
+        object: 'Object1',
+        modifyAllRecords: true,
+        viewAllRecords: true,
       });
-      it('should return a warning when allowDelete is true', () => {
-        const objectPermission = new ProfileObjectPermission(profile, { object: 'Object1', allowDelete: true });
-        const results = ruleset['objectPermissionWarnings'](objectPermission);
-        expect(results.length).to.equal(1);
-        expect(results[0].problem).to.equal('<allowDelete> permission should not be true for Object1 object');
+      const results = ruleset['objectPermissionWarnings'](objectPermission);
+      expect(results.length).to.equal(2);
+      expect(results[0].problem).to.equal('<modifyAllRecords> permission should not be true for Object1 object');
+      expect(results[1].problem).to.equal('<viewAllRecords> permission should not be true for Object1 object');
+    });
+
+    it('should not return any warnings when all object permissions are false', () => {
+      const objectPermission = new ProfileObjectPermission(profile, {
+        field: 'Object1',
+        allowCreate: false,
+        allowDelete: false,
+        allowEdit: false,
+        allowRead: false,
+        modifyAllRecords: false,
+        viewAllRecords: false,
       });
-      it('should return a warning when allowEdit is true', () => {
-        const objectPermission = new ProfileObjectPermission(profile, { object: 'Object1', allowEdit: true });
-        const results = ruleset['objectPermissionWarnings'](objectPermission);
-        expect(results.length).to.equal(1);
-        expect(results[0].problem).to.equal('<allowEdit> permission should not be true for Object1 object');
-      });
-      it('should return a warning when allowRead is true', () => {
-        const objectPermission = new ProfileObjectPermission(profile, { object: 'Object1', allowRead: true });
-        const results = ruleset['objectPermissionWarnings'](objectPermission);
-        expect(results.length).to.equal(1);
-        expect(results[0].problem).to.equal('<allowRead> permission should not be true for Object1 object');
-      });
-      it('should return a warning when modifyAllRecords is true', () => {
-        const objectPermission = new ProfileObjectPermission(profile, { object: 'Object1', modifyAllRecords: true });
-        const results = ruleset['objectPermissionWarnings'](objectPermission);
-        expect(results.length).to.equal(1);
-        expect(results[0].problem).to.equal('<modifyAllRecords> permission should not be true for Object1 object');
-      });
-      it('should return a warning when viewAllRecords is true', () => {
-        const objectPermission = new ProfileObjectPermission(profile, { object: 'Object1', viewAllRecords: true });
-        const results = ruleset['objectPermissionWarnings'](objectPermission);
-        expect(results.length).to.equal(1);
-        expect(results[0].problem).to.equal('<viewAllRecords> permission should not be true for Object1 object');
-      });
-      it('should not return any warnings when all object permissions are false', () => {
-        const objectPermission = new ProfileObjectPermission(profile, {
-          field: 'Object1',
-          allowCreate: false,
-          allowDelete: false,
-          allowEdit: false,
-          allowRead: false,
-          modifyAllRecords: false,
-          viewAllRecords: false,
-        });
-        const results = ruleset['objectPermissionWarnings'](objectPermission);
-        expect(results.length).to.equal(0);
-      });
+      const results = ruleset['objectPermissionWarnings'](objectPermission);
+      expect(results.length).to.equal(0);
     });
   });
 });

--- a/src/ruleset/minimumAccessProfileRuleset.test.ts
+++ b/src/ruleset/minimumAccessProfileRuleset.test.ts
@@ -1,0 +1,21 @@
+import 'mocha';
+import { expect } from 'chai';
+import { Profile, ProfileFieldPermission } from '../metadata_browser/profile';
+import { MinimumAccessProfileRuleset } from './minimumAccessProfileRuleset';
+
+describe('MinimumAccessProfileRuleset', () => {
+  describe('.fieldPermissionWarnings()', () => {
+    it('returns a warning when a field is editable', () => {
+      const profile = new Profile('MinimumAccess.profile-meta.xml');
+      const fieldPermission = new ProfileFieldPermission(profile, { field: 'Object1.Field1', editable: true });
+      const ruleset = new MinimumAccessProfileRuleset(null);
+      const results = ruleset['fieldPermissionWarnings'](fieldPermission);
+      expect(results.length).to.equal(1);
+      expect(results[0].componentName).to.equal('MinimumAccess');
+      expect(results[0].componentType).to.equal('Profile');
+      expect(results[0].fileName).to.equal('MinimumAccess.profile-meta.xml');
+      expect(results[0].problem).to.equal('<editable> permission should not be true for Object1.Field1 field');
+      expect(results[0].problemType).to.equal('Warning');
+    });
+  });
+});

--- a/src/ruleset/minimumAccessProfileRuleset.ts
+++ b/src/ruleset/minimumAccessProfileRuleset.ts
@@ -1,0 +1,80 @@
+import { Profile, ProfileFieldPermission, ProfileObjectPermission } from '../metadata_browser/profile';
+import { MetadataProblem, MetadataWarning } from './metadataProblem';
+import { MetadataRuleset } from './metadataRuleset';
+
+export class MinimumAccessProfileRuleset extends MetadataRuleset {
+  public displayName = 'Minimum Access profile';
+
+  public run(): MetadataProblem[] {
+    const minAccessProfile = this.sfdxProjectBrowser.profileByName('Minimum Access');
+    return this.checkProfile(minAccessProfile);
+  }
+
+  private checkProfile(profile: Profile): MetadataProblem[] {
+    return this.fieldPermissionWarnings(profile).concat(this.objectPermissionWarnings(profile));
+  }
+
+  // Rule 1:
+  // In a Minimum Access profile, no <fieldPermission> may be editable or readable
+  private fieldPermissionWarnings(profile: Profile): MetadataWarning[] {
+    const results: MetadataWarning[] = [];
+
+    for (const fieldPermission of profile.fieldPermissions()) {
+      if (fieldPermission.editable) {
+        results.push(this.newFieldPermissionWarning(profile, fieldPermission, 'editable'));
+      }
+      if (fieldPermission.readable) {
+        results.push(this.newFieldPermissionWarning(profile, fieldPermission, 'readable'));
+      }
+    }
+
+    return results;
+  }
+
+  private newFieldPermissionWarning(
+    profile: Profile,
+    fieldPermission: ProfileFieldPermission,
+    permissionName: string
+  ): MetadataWarning {
+    const message = `<${permissionName}> permission should not be true for field ${fieldPermission.objectFieldName}`;
+    return new MetadataWarning(profile.name, 'Profile', profile.fileName, message);
+  }
+
+  // Rule 2:
+  // In a Minimum Access profile, no <objectPermissions> may be true
+  private objectPermissionWarnings(profile: Profile): MetadataWarning[] {
+    const results: MetadataWarning[] = [];
+
+    for (const objectPermission of profile.objectPermissions()) {
+      if (objectPermission.allowCreate) {
+        results.push(this.newObjectPermissionWarning(profile, objectPermission, 'allowCreate'));
+      }
+      if (objectPermission.allowDelete) {
+        results.push(this.newObjectPermissionWarning(profile, objectPermission, 'allowDelete'));
+      }
+      if (objectPermission.allowEdit) {
+        results.push(this.newObjectPermissionWarning(profile, objectPermission, 'allowEdit'));
+      }
+      if (objectPermission.allowRead) {
+        results.push(this.newObjectPermissionWarning(profile, objectPermission, 'allowRead'));
+      }
+      if (objectPermission.modifyAllRecords) {
+        results.push(this.newObjectPermissionWarning(profile, objectPermission, 'modifyAllRecords'));
+      }
+      if (objectPermission.viewAllRecords) {
+        results.push(this.newObjectPermissionWarning(profile, objectPermission, 'viewAllRecords'));
+      }
+    }
+
+    return results;
+  }
+
+  private newObjectPermissionWarning(
+    profile: Profile,
+    objectPermission: ProfileObjectPermission,
+    permissionName: string
+  ): MetadataWarning {
+    const message = `<${permissionName}> permission should not be true for object ${objectPermission.objectName}`;
+    return new MetadataWarning(profile.name, 'Profile', profile.fileName, message);
+  }
+}

--- a/src/ruleset/minimumAccessProfileRuleset.ts
+++ b/src/ruleset/minimumAccessProfileRuleset.ts
@@ -11,70 +11,72 @@ export class MinimumAccessProfileRuleset extends MetadataRuleset {
   }
 
   private checkProfile(profile: Profile): MetadataProblem[] {
-    return this.fieldPermissionWarnings(profile).concat(this.objectPermissionWarnings(profile));
+    const fieldwarnings = profile
+      .fieldPermissions()
+      .map((fp) => this.fieldPermissionWarnings(fp))
+      .flat();
+
+    const objectWarnings = profile
+      .objectPermissions()
+      .map((op) => this.objectPermissionWarnings(op))
+      .flat();
+
+    return fieldwarnings.concat(objectWarnings);
   }
 
   // Rule 1:
   // In a Minimum Access profile, no <fieldPermission> may be editable or readable
-  private fieldPermissionWarnings(profile: Profile): MetadataWarning[] {
+  private fieldPermissionWarnings(fieldPermission: ProfileFieldPermission): MetadataWarning[] {
     const results: MetadataWarning[] = [];
 
-    for (const fieldPermission of profile.fieldPermissions()) {
-      if (fieldPermission.editable) {
-        results.push(this.newFieldPermissionWarning(profile, fieldPermission, 'editable'));
-      }
-      if (fieldPermission.readable) {
-        results.push(this.newFieldPermissionWarning(profile, fieldPermission, 'readable'));
-      }
+    if (fieldPermission.editable) {
+      results.push(this.newFieldPermissionWarning(fieldPermission, 'editable'));
+    }
+
+    if (fieldPermission.readable) {
+      results.push(this.newFieldPermissionWarning(fieldPermission, 'readable'));
     }
 
     return results;
   }
 
-  private newFieldPermissionWarning(
-    profile: Profile,
-    fieldPermission: ProfileFieldPermission,
-    permissionName: string
-  ): MetadataWarning {
-    const message = `<${permissionName}> permission should not be true for field ${fieldPermission.objectFieldName}`;
-    return new MetadataWarning(profile.name, 'Profile', profile.fileName, message);
+  private newFieldPermissionWarning(fieldPermission: ProfileFieldPermission, permissionName: string): MetadataWarning {
+    const message = `<${permissionName}> permission should not be true for ${fieldPermission.objectFieldName} field`;
+    return new MetadataWarning(fieldPermission.profile.name, 'Profile', fieldPermission.profile.fileName, message);
   }
 
   // Rule 2:
   // In a Minimum Access profile, no <objectPermissions> may be true
-  private objectPermissionWarnings(profile: Profile): MetadataWarning[] {
+  private objectPermissionWarnings(objectPermission: ProfileObjectPermission): MetadataWarning[] {
     const results: MetadataWarning[] = [];
 
-    for (const objectPermission of profile.objectPermissions()) {
-      if (objectPermission.allowCreate) {
-        results.push(this.newObjectPermissionWarning(profile, objectPermission, 'allowCreate'));
-      }
-      if (objectPermission.allowDelete) {
-        results.push(this.newObjectPermissionWarning(profile, objectPermission, 'allowDelete'));
-      }
-      if (objectPermission.allowEdit) {
-        results.push(this.newObjectPermissionWarning(profile, objectPermission, 'allowEdit'));
-      }
-      if (objectPermission.allowRead) {
-        results.push(this.newObjectPermissionWarning(profile, objectPermission, 'allowRead'));
-      }
-      if (objectPermission.modifyAllRecords) {
-        results.push(this.newObjectPermissionWarning(profile, objectPermission, 'modifyAllRecords'));
-      }
-      if (objectPermission.viewAllRecords) {
-        results.push(this.newObjectPermissionWarning(profile, objectPermission, 'viewAllRecords'));
-      }
+    if (objectPermission.allowCreate) {
+      results.push(this.newObjectPermissionWarning(objectPermission, 'allowCreate'));
+    }
+    if (objectPermission.allowDelete) {
+      results.push(this.newObjectPermissionWarning(objectPermission, 'allowDelete'));
+    }
+    if (objectPermission.allowEdit) {
+      results.push(this.newObjectPermissionWarning(objectPermission, 'allowEdit'));
+    }
+    if (objectPermission.allowRead) {
+      results.push(this.newObjectPermissionWarning(objectPermission, 'allowRead'));
+    }
+    if (objectPermission.modifyAllRecords) {
+      results.push(this.newObjectPermissionWarning(objectPermission, 'modifyAllRecords'));
+    }
+    if (objectPermission.viewAllRecords) {
+      results.push(this.newObjectPermissionWarning(objectPermission, 'viewAllRecords'));
     }
 
     return results;
   }
 
   private newObjectPermissionWarning(
-    profile: Profile,
     objectPermission: ProfileObjectPermission,
     permissionName: string
   ): MetadataWarning {
-    const message = `<${permissionName}> permission should not be true for object ${objectPermission.objectName}`;
-    return new MetadataWarning(profile.name, 'Profile', profile.fileName, message);
+    const message = `<${permissionName}> permission should not be true for ${objectPermission.objectName} object`;
+    return new MetadataWarning(objectPermission.profile.name, 'Profile', objectPermission.profile.fileName, message);
   }
 }

--- a/src/ruleset/minimumAccessProfileRuleset.ts
+++ b/src/ruleset/minimumAccessProfileRuleset.ts
@@ -1,12 +1,19 @@
 import { Profile, ProfileFieldPermission, ProfileObjectPermission } from '../metadata_browser/profile';
+import { SfdxProjectBrowser } from '../metadata_browser/sfdxProjectBrowser';
 import { MetadataProblem, MetadataWarning } from './metadataProblem';
 import { MetadataRuleset } from './metadataRuleset';
 
 export class MinimumAccessProfileRuleset extends MetadataRuleset {
   public displayName = 'Minimum Access profile';
+  public profileName: string;
+
+  public constructor(sfdxProjectBrowser: SfdxProjectBrowser, profileName: string) {
+    super(sfdxProjectBrowser);
+    this.profileName = profileName;
+  }
 
   public run(): MetadataProblem[] {
-    const minAccessProfile = this.sfdxProjectBrowser.profileByName('Minimum Access - Salesforce');
+    const minAccessProfile = this.sfdxProjectBrowser.profileByName(this.profileName);
     return this.checkProfile(minAccessProfile);
   }
 

--- a/src/ruleset/minimumAccessProfileRuleset.ts
+++ b/src/ruleset/minimumAccessProfileRuleset.ts
@@ -6,7 +6,7 @@ export class MinimumAccessProfileRuleset extends MetadataRuleset {
   public displayName = 'Minimum Access profile';
 
   public run(): MetadataProblem[] {
-    const minAccessProfile = this.sfdxProjectBrowser.profileByName('Minimum Access');
+    const minAccessProfile = this.sfdxProjectBrowser.profileByName('Minimum Access - Salesforce');
     return this.checkProfile(minAccessProfile);
   }
 
@@ -40,7 +40,7 @@ export class MinimumAccessProfileRuleset extends MetadataRuleset {
   }
 
   private newFieldPermissionWarning(fieldPermission: ProfileFieldPermission, permissionName: string): MetadataWarning {
-    const message = `<${permissionName}> permission should not be true for ${fieldPermission.objectFieldName} field`;
+    const message = `<${permissionName}> permission should not be true for ${fieldPermission.objectFieldName}`;
     return new MetadataWarning(fieldPermission.profile.name, 'Profile', fieldPermission.profile.fileName, message);
   }
 

--- a/src/ruleset/minimumAccessProfileRuleset.ts
+++ b/src/ruleset/minimumAccessProfileRuleset.ts
@@ -32,7 +32,6 @@ export class MinimumAccessProfileRuleset extends MetadataRuleset {
     if (fieldPermission.editable) {
       results.push(this.newFieldPermissionWarning(fieldPermission, 'editable'));
     }
-
     if (fieldPermission.readable) {
       results.push(this.newFieldPermissionWarning(fieldPermission, 'readable'));
     }


### PR DESCRIPTION
### Description

Ruleset to keep watch over the Minimum Access profile. 

Raises warnings if you set any `<fieldPermissions>` (editable, readable) or  `<objectPermissions>` (allowCreate etc) to true.


### Notes
This is the 'MVP' version. It's not as aggressive as the Admin profile ruleset, in that:
* it doesn't raise a warning if there a no `<fieldPermissions>` for a particular field (similar for objects)
* it doesn't raise warnings for fields/objects that are sorted out-of-order