### PR TITLE
Queues Ruleset

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,10 @@ When you add a new picklist field to an object, Salesforce automatically adds a 
 
 Examines record types & checks for picklist values that don't exist (or are inactive) in the corresponding picklist field definitions.
 
+### Queues
+
+Examines queues & raises warnings if any contain users as direct members. This can lead to deployment failures if users don't exist in target environments. Preferred approach is to use public groups or roles for queue membership.
+
 ## Problem categories
 
 ### Errors

--- a/src/commands/dxcop/source/check.ts
+++ b/src/commands/dxcop/source/check.ts
@@ -15,6 +15,7 @@ import { MetadataRuleset } from '../../../ruleset/metadataRuleset';
 import { MinimumAccessProfileRuleset } from '../../../ruleset/minimumAccessProfileRuleset';
 import { RecordTypePicklistRuleset } from '../../../ruleset/recordTypePicklistRuleset';
 import { RecordTypePicklistValueRuleset } from '../../../ruleset/recordTypePicklistValueRuleset';
+import { QueueRuleset } from '../../../ruleset/queueRuleset';
 
 // Initialize Messages with the current plugin directory
 Messages.importMessagesDirectory(__dirname);
@@ -80,6 +81,9 @@ export default class Check extends SfdxCommand {
       rulesets.push(
         new MinimumAccessProfileRuleset(sfdxProjectBrowser, config.ruleSets.minimumAccessProfile.profileName)
       );
+    }
+    if (config.ruleSets.queues.enabled) {
+      rulesets.push(new QueueRuleset(sfdxProjectBrowser));
     }
     if (config.ruleSets.recordTypePicklists.enabled) {
       rulesets.push(new RecordTypePicklistRuleset(sfdxProjectBrowser));

--- a/src/config/defaultConfig.ts
+++ b/src/config/defaultConfig.ts
@@ -8,6 +8,7 @@ export default function defaultConfig() {
       emailToCaseSettings: { enabled: true },
       lightningWebComponents: { enabled: true },
       minimumAccessProfile: { enabled: false, profileName: 'Minimum Access - Salesforce' },
+      queues: { enabled: false },
       recordTypePicklists: { enabled: true },
       recordTypePicklistValues: { enabled: true },
     },

--- a/src/metadata_browser/queue.test.ts
+++ b/src/metadata_browser/queue.test.ts
@@ -1,0 +1,71 @@
+import 'mocha';
+import { expect } from 'chai';
+import { Queue } from './queue';
+
+describe('Queue', () => {
+  const fileName = 'Test.queue-meta.xml';
+
+  describe('.users()', () => {
+    context('when there are no queue members', () => {
+      const xml = `<?xml version="1.0" encoding="UTF-8"?>
+        <Queue xmlns="http://soap.sforce.com/2006/04/metadata">
+            <doesSendEmailToMembers>false</doesSendEmailToMembers>
+            <name>Test</name>
+            <queueSobject>
+                <sobjectType>Case</sobjectType>
+            </queueSobject>
+        </Queue>`;
+
+      it('returns an empty array', () => {
+        const queue = new Queue(fileName, xml);
+        expect(queue.queueMembers().users().length).to.equal(0);
+      });
+    });
+
+    context('when the queue has one user', () => {
+      const xml = `<?xml version="1.0" encoding="UTF-8"?>
+        <Queue xmlns="http://soap.sforce.com/2006/04/metadata">
+            <doesSendEmailToMembers>false</doesSendEmailToMembers>
+            <name>Test</name>
+            <queueMembers>
+                <users>
+                    <user>test@test.com</user>
+                </users>
+            </queueMembers>
+            <queueSobject>
+                <sobjectType>Case</sobjectType>
+            </queueSobject>
+        </Queue>`;
+
+      it('returns an array with one user', () => {
+        const users = new Queue(fileName, xml).queueMembers().users();
+        expect(users.length).to.equal(1);
+        expect(users[0]).to.equal('test@test.com');
+      });
+    });
+
+    context('when the queue has more than one user', () => {
+      const xml = `<?xml version="1.0" encoding="UTF-8"?>
+        <Queue xmlns="http://soap.sforce.com/2006/04/metadata">
+            <doesSendEmailToMembers>false</doesSendEmailToMembers>
+            <name>Test</name>
+            <queueMembers>
+                <users>
+                    <user>test1@test.com</user>
+                    <user>test2@test.com</user>
+                </users>
+            </queueMembers>
+            <queueSobject>
+                <sobjectType>Case</sobjectType>
+            </queueSobject>
+        </Queue>`;
+
+      it('returns an array of all the users', () => {
+        const users = new Queue(fileName, xml).queueMembers().users();
+        expect(users.length).to.equal(2);
+        expect(users[0]).to.equal('test1@test.com');
+        expect(users[1]).to.equal('test2@test.com');
+      });
+    });
+  });
+});

--- a/src/metadata_browser/queue.ts
+++ b/src/metadata_browser/queue.ts
@@ -1,0 +1,42 @@
+import {
+  AnyJson,
+  getJsonArray,
+  getJsonMap,
+  getString,
+  hasJsonArray,
+  hasJsonMap,
+  hasString,
+} from '@salesforce/ts-types';
+import { MetadataComponent } from './metadataComponent';
+
+export class Queue extends MetadataComponent {
+  protected readonly fileExtension = 'queue';
+  protected readonly metadataType = 'Queue';
+
+  public queueMembers(): QueueMembers {
+    return new QueueMembers(getJsonMap(this.metadata, 'queueMembers'));
+  }
+}
+
+export class QueueMembers {
+  private readonly metadata: AnyJson;
+
+  public constructor(metadata: AnyJson) {
+    this.metadata = metadata;
+  }
+
+  // Return an array of usernames, for users that are direct members of the queue (or empty array if no users)
+  public users(): string[] {
+    if (hasJsonMap(this.metadata, 'users')) {
+      const users = getJsonMap(this.metadata, 'users');
+
+      if (hasJsonArray(users, 'user')) {
+        return getJsonArray(users, 'user').map((u) => u.toString());
+      } else if (hasString(users, 'user')) {
+        return [getString(users, 'user').toString()];
+      }
+    }
+
+    return [];
+  }
+}

--- a/src/metadata_browser/sfdxProjectBrowser.test.ts
+++ b/src/metadata_browser/sfdxProjectBrowser.test.ts
@@ -9,7 +9,7 @@ describe('SfdxProjectBrowser', () => {
     it('returns an array of LightningComponentBundle objects', () => {
       const sfdxProjectBrowser = new SfdxProjectBrowser(null);
       const mockProjectBrowser = sinon.mock(sfdxProjectBrowser);
-      mockProjectBrowser.expects('lwcBaseDir').once().returns('src/test/metadata/lwc');
+      mockProjectBrowser.expects('defaultDir').once().returns('src/test/metadata');
 
       const results = sfdxProjectBrowser.lwcBundles();
       expect(results.length).to.equal(2);
@@ -21,16 +21,30 @@ describe('SfdxProjectBrowser', () => {
     });
   });
 
-  describe('.objects', () => {
+  describe('.objects()', () => {
     it('returns an array of CustomObject objects', () => {
       const sfdxProjectBrowser = new SfdxProjectBrowser(null);
       const mockProjectBrowser = sinon.mock(sfdxProjectBrowser);
-      mockProjectBrowser.expects('objectsBaseDir').once().returns('src/test/metadata/objects');
+      mockProjectBrowser.expects('defaultDir').once().returns('src/test/metadata');
 
       const results = sfdxProjectBrowser.objects();
       expect(results.length).to.equal(2);
       expect(results[0].name).to.equal('TestObject1');
       expect(results[1].name).to.equal('TestObject2');
+      mockProjectBrowser.verify();
+    });
+  });
+
+  describe('.queues()', () => {
+    it('returns an array of Queue objects', () => {
+      const sfdxProjectBrowser = new SfdxProjectBrowser(null);
+      const mockProjectBrowser = sinon.mock(sfdxProjectBrowser);
+      mockProjectBrowser.expects('defaultDir').once().returns('src/test/metadata');
+
+      const results = sfdxProjectBrowser.queues();
+      expect(results.length).to.equal(2);
+      expect(results[0].name).to.equal('Queue_With_No_Members');
+      expect(results[1].name).to.equal('Queue_With_Users');
       mockProjectBrowser.verify();
     });
   });

--- a/src/metadata_browser/sfdxProjectBrowser.ts
+++ b/src/metadata_browser/sfdxProjectBrowser.ts
@@ -8,6 +8,7 @@ import { LightningComponentBundle } from './lightningComponentBundle';
 import { PicklistField } from './picklistField';
 import { Profile } from './profile';
 import { RecordType } from './recordType';
+import { Queue } from './queue';
 
 // Tools for browsing/navigating the metadata in an SFDX project
 export class SfdxProjectBrowser {
@@ -79,6 +80,12 @@ export class SfdxProjectBrowser {
     return new Profile(fileName);
   }
 
+  public queues(): Queue[] {
+    const dir = this.queuesBaseDir();
+    const fileNames = fs.existsSync(dir) ? fs.readdirSync(dir) : [];
+    return fileNames.map((f) => new Queue(path.join(dir, f)));
+  }
+
   // Return a list of record types for the given object
   public recordTypes(objectName: string): RecordType[] {
     const dir = this.recordTypesBaseDir(objectName);
@@ -134,6 +141,10 @@ export class SfdxProjectBrowser {
   // Directory containing custom objects
   private objectsBaseDir(): string {
     return path.join(this.defaultDir(), 'objects');
+  }
+
+  private queuesBaseDir(): string {
+    return path.join(this.defaultDir(), 'queues');
   }
 
   private settingsBaseDir(): string {

--- a/src/ruleset/queueRuleset.test.ts
+++ b/src/ruleset/queueRuleset.test.ts
@@ -7,40 +7,18 @@ import { QueueRuleset } from './queueRuleset';
 
 describe('QueueRuleset', () => {
   describe('.run()', () => {
-    const queueWithNoUsersXml = `<?xml version="1.0" encoding="UTF-8"?>
-    <Queue xmlns="http://soap.sforce.com/2006/04/metadata">
-        <doesSendEmailToMembers>false</doesSendEmailToMembers>
-        <name>Test</name>
-        <queueSobject>
-            <sobjectType>Case</sobjectType>
-        </queueSobject>
-    </Queue>`;
-
-    const queueWithUsersXml = `<?xml version="1.0" encoding="UTF-8"?>
-    <Queue xmlns="http://soap.sforce.com/2006/04/metadata">
-        <doesSendEmailToMembers>false</doesSendEmailToMembers>
-        <name>Test</name>
-        <queueMembers>
-            <users>
-                <user>test@test.com</user>
-            </users>
-        </queueMembers>
-        <queueSobject>
-            <sobjectType>Case</sobjectType>
-        </queueSobject>
-    </Queue>`;
-
-    const queueWithNoUsers = new Queue('Test1.queue-meta.xml', queueWithNoUsersXml);
-    const queueWithUsers = new Queue('Test2.queue-meta.xml', queueWithUsersXml);
+    const queueWithNoMembers = new Queue('src/test/metadata/queues/Queue_With_No_Members.queue-meta.xml');
+    const queueWithUsers = new Queue('src/test/metadata/queues/Queue_With_Users.queue-meta.xml');
 
     it('returns a warning if a queue has users', () => {
       const sfdxProjectBrowser = new SfdxProjectBrowser(null);
-      sinon.stub(sfdxProjectBrowser, 'queues').returns([queueWithNoUsers, queueWithUsers]);
+      sinon.stub(sfdxProjectBrowser, 'queues').returns([queueWithNoMembers, queueWithUsers]);
 
       const ruleset = new QueueRuleset(sfdxProjectBrowser);
       const results = ruleset.run();
 
       expect(results.length).to.equal(1);
+      expect(results[0].problem).to.equal('Users should not be direct members of queues');
     });
   });
 });

--- a/src/ruleset/queueRuleset.test.ts
+++ b/src/ruleset/queueRuleset.test.ts
@@ -1,0 +1,46 @@
+import 'mocha';
+import { expect } from 'chai';
+import sinon = require('sinon');
+import { SfdxProjectBrowser } from '../metadata_browser/sfdxProjectBrowser';
+import { Queue } from '../metadata_browser/queue';
+import { QueueRuleset } from './queueRuleset';
+
+describe('QueueRuleset', () => {
+  describe('.run()', () => {
+    const queueWithNoUsersXml = `<?xml version="1.0" encoding="UTF-8"?>
+    <Queue xmlns="http://soap.sforce.com/2006/04/metadata">
+        <doesSendEmailToMembers>false</doesSendEmailToMembers>
+        <name>Test</name>
+        <queueSobject>
+            <sobjectType>Case</sobjectType>
+        </queueSobject>
+    </Queue>`;
+
+    const queueWithUsersXml = `<?xml version="1.0" encoding="UTF-8"?>
+    <Queue xmlns="http://soap.sforce.com/2006/04/metadata">
+        <doesSendEmailToMembers>false</doesSendEmailToMembers>
+        <name>Test</name>
+        <queueMembers>
+            <users>
+                <user>test@test.com</user>
+            </users>
+        </queueMembers>
+        <queueSobject>
+            <sobjectType>Case</sobjectType>
+        </queueSobject>
+    </Queue>`;
+
+    const queueWithNoUsers = new Queue('Test1.queue-meta.xml', queueWithNoUsersXml);
+    const queueWithUsers = new Queue('Test2.queue-meta.xml', queueWithUsersXml);
+
+    it('returns a warning if a queue has users', () => {
+      const sfdxProjectBrowser = new SfdxProjectBrowser(null);
+      sinon.stub(sfdxProjectBrowser, 'queues').returns([queueWithNoUsers, queueWithUsers]);
+
+      const ruleset = new QueueRuleset(sfdxProjectBrowser);
+      const results = ruleset.run();
+
+      expect(results.length).to.equal(1);
+    });
+  });
+});

--- a/src/ruleset/queueRuleset.ts
+++ b/src/ruleset/queueRuleset.ts
@@ -1,0 +1,24 @@
+import { Queue } from '../metadata_browser/queue';
+import { MetadataProblem, MetadataWarning } from './metadataProblem';
+import { MetadataRuleset } from './metadataRuleset';
+
+export class QueueRuleset extends MetadataRuleset {
+  public displayName = 'Queues';
+
+  public run(): MetadataProblem[] {
+    const queues = this.sfdxProjectBrowser.queues();
+    return queues.map((q) => this.queueProblems(q)).flat();
+  }
+
+  private queueProblems(queue: Queue): MetadataProblem[] {
+    if (queue.queueMembers().users().length > 0) {
+      return [this.queueHasUsersWarning(queue)];
+    }
+    return [];
+  }
+
+  private queueHasUsersWarning(queue: Queue): MetadataWarning {
+    const message = 'Users should not be direct members of queues';
+    return new MetadataWarning(queue.name, 'Queue', queue.fileName, message);
+  }
+}

--- a/src/test/metadata/queues/Queue_With_No_Members.queue-meta.xml
+++ b/src/test/metadata/queues/Queue_With_No_Members.queue-meta.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Queue xmlns="http://soap.sforce.com/2006/04/metadata">
+    <doesSendEmailToMembers>false</doesSendEmailToMembers>
+    <name>Queue With No Members</name>
+    <queueSobject>
+        <sobjectType>Case</sobjectType>
+    </queueSobject>
+</Queue>

--- a/src/test/metadata/queues/Queue_With_Users.queue-meta.xml
+++ b/src/test/metadata/queues/Queue_With_Users.queue-meta.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Queue xmlns="http://soap.sforce.com/2006/04/metadata">
+    <doesSendEmailToMembers>false</doesSendEmailToMembers>
+    <name>Queue With Users</name>
+    <queueMembers>
+        <users>
+            <user>test1@test.com</user>
+            <user>test2@test.com</user>
+        </users>
+    </queueMembers>
+    <queueSobject>
+        <sobjectType>Case</sobjectType>
+    </queueSobject>
+</Queue>


### PR DESCRIPTION
### Summary
New Ruleset for Queues

### Description
Checks all Queues in the project. Raises a warning for any queue that contains users as direct members of the queue.

#### Rationale
Users that exist in one environment may not exist in all environments. If a user referenced in the queue metadata does not exist in the target org, deployment will fail. i.e. deployment success is not guaranteed across all environments.

#### Preferred approach
Users should not be referenced directly in queue metadata. This can be achieved in a number of ways:
1. The simplest method is to avoid making users members of queues directly. Preference is to use public groups or roles.
2. Remove the `<queueMembers>` part of the metadata before committing to git, then manage queue membership entirely outside the release cycle. (Advanced approach - be sure to test!)