### PR TITLE
Installed Packages Ruleset

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ Ensures you don't have the `<emailServicesAddress>` and `<isVerified>` fields st
 
 Also ensures that `<routingAddresses>` are ordered by `<routingName>`.
 
+### Installed Packages
+
+A common problem when retrieving Installed Packages is that they contain `<activateRSS xsi:nil="true"/>`, which fails to deploy since `<activateRSS>` is a required field. It must be explicity set e.g. to `<activateRSS>false</activateRSS>`. This ruleset will report the problem early, to avoid failed deployments.
+
 ### Lightning web components
 
 Checks `*.js-meta.xml` files for extra whitespace at the ends of lines. This can cause unexpected behaviour when you retrieve the same component after deployment; extra lines of whitespace can be inserted resulting in unexpected file differences.

--- a/src/commands/dxcop/source/check.test.ts
+++ b/src/commands/dxcop/source/check.test.ts
@@ -35,7 +35,7 @@ describe('dxcop:source:check command', () => {
     it('should create a ruleset object for each ruleset enabled in the (default) config', () => {
       const checkCommand = new Check([], null);
       const ruleSets = checkCommand['rulesetsToRun'](null);
-      expect(ruleSets.length).to.equal(4);
+      expect(ruleSets.length).to.equal(5);
     });
   });
 });

--- a/src/commands/dxcop/source/check.ts
+++ b/src/commands/dxcop/source/check.ts
@@ -16,6 +16,7 @@ import { MinimumAccessProfileRuleset } from '../../../ruleset/minimumAccessProfi
 import { RecordTypePicklistRuleset } from '../../../ruleset/recordTypePicklistRuleset';
 import { RecordTypePicklistValueRuleset } from '../../../ruleset/recordTypePicklistValueRuleset';
 import { QueueRuleset } from '../../../ruleset/queueRuleset';
+import { InstalledPackageRuleset } from '../../../ruleset/installedPackageRuleset';
 
 // Initialize Messages with the current plugin directory
 Messages.importMessagesDirectory(__dirname);
@@ -73,6 +74,9 @@ export default class Check extends SfdxCommand {
     }
     if (config.ruleSets.emailToCaseSettings.enabled) {
       rulesets.push(new EmailToCaseSettingsRuleset(sfdxProjectBrowser));
+    }
+    if (config.ruleSets.installedPackages.enabled) {
+      rulesets.push(new InstalledPackageRuleset(sfdxProjectBrowser));
     }
     if (config.ruleSets.lightningWebComponents.enabled) {
       rulesets.push(new LwcMetadataRuleset(sfdxProjectBrowser));

--- a/src/config/defaultConfig.ts
+++ b/src/config/defaultConfig.ts
@@ -6,6 +6,7 @@ export default function defaultConfig() {
     ruleSets: {
       adminProfile: { enabled: false },
       emailToCaseSettings: { enabled: true },
+      installedPackages: { enabled: true },
       lightningWebComponents: { enabled: true },
       minimumAccessProfile: { enabled: false, profileName: 'Minimum Access - Salesforce' },
       queues: { enabled: false },

--- a/src/metadata_browser/installedPackage.test.ts
+++ b/src/metadata_browser/installedPackage.test.ts
@@ -1,0 +1,57 @@
+import 'mocha';
+import { expect } from 'chai';
+import { InstalledPackage } from './installedPackage';
+
+describe('InstalledPackage', () => {
+  const fileName = 'Test.installedPackage-meta.xml';
+
+  describe('.activateRSS()', () => {
+    context('when <activateRSS> is true', () => {
+      const xml = `<?xml version="1.0" encoding="UTF-8"?>
+      <InstalledPackage xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+          <activateRSS>true</activateRSS>
+      </InstalledPackage>`;
+
+      it('returns true', () => {
+        const installedPackage = new InstalledPackage(fileName, xml);
+        expect(installedPackage.activateRSS).to.equal(true);
+      });
+    });
+
+    context('when <activateRSS> is false', () => {
+      const xml = `<?xml version="1.0" encoding="UTF-8"?>
+      <InstalledPackage xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+          <activateRSS>false</activateRSS>
+      </InstalledPackage>`;
+
+      it('returns false', () => {
+        const installedPackage = new InstalledPackage(fileName, xml);
+        expect(installedPackage.activateRSS).to.equal(false);
+      });
+    });
+
+    context('when <activateRSS> is empty', () => {
+      const xml = `<?xml version="1.0" encoding="UTF-8"?>
+      <InstalledPackage xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+          <activateRSS xsi:nil="true"/>
+      </InstalledPackage>`;
+
+      it('returns null', () => {
+        const installedPackage = new InstalledPackage(fileName, xml);
+        expect(installedPackage.activateRSS).to.equal(null);
+      });
+    });
+
+    context('when <activateRSS> element is not present', () => {
+      const xml = `<?xml version="1.0" encoding="UTF-8"?>
+      <InstalledPackage xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+          <versionNumber>1.23</versionNumber>
+      </InstalledPackage>`;
+
+      it('returns undefined', () => {
+        const installedPackage = new InstalledPackage(fileName, xml);
+        expect(installedPackage.activateRSS).to.equal(undefined);
+      });
+    });
+  });
+});

--- a/src/metadata_browser/installedPackage.test.ts
+++ b/src/metadata_browser/installedPackage.test.ts
@@ -5,7 +5,7 @@ import { InstalledPackage } from './installedPackage';
 describe('InstalledPackage', () => {
   const fileName = 'Test.installedPackage-meta.xml';
 
-  describe('.activateRSS()', () => {
+  describe('.activateRSS', () => {
     context('when <activateRSS> is true', () => {
       const xml = `<?xml version="1.0" encoding="UTF-8"?>
       <InstalledPackage xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
@@ -51,6 +51,56 @@ describe('InstalledPackage', () => {
       it('returns undefined', () => {
         const installedPackage = new InstalledPackage(fileName, xml);
         expect(installedPackage.activateRSS).to.equal(undefined);
+      });
+    });
+
+    context('when <activateRSS> is not a boolean', () => {
+      const xml = `<?xml version="1.0" encoding="UTF-8"?>
+      <InstalledPackage xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+          <activateRSS>17</activateRSS>
+      </InstalledPackage>`;
+
+      it('returns undefined', () => {
+        const installedPackage = new InstalledPackage(fileName, xml);
+        expect(installedPackage.activateRSS).to.equal(undefined);
+      });
+    });
+  });
+
+  describe('.securityType', () => {
+    context('when <securityType> contains a value', () => {
+      const xml = `<?xml version="1.0" encoding="UTF-8"?>
+      <InstalledPackage xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+          <securityType>AllUsers</securityType>
+      </InstalledPackage>`;
+
+      it('returns the value as a string', () => {
+        const installedPackage = new InstalledPackage(fileName, xml);
+        expect(installedPackage.securityType).to.equal('AllUsers');
+      });
+    });
+
+    context('when <securityType> is empty', () => {
+      const xml = `<?xml version="1.0" encoding="UTF-8"?>
+      <InstalledPackage xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+          <securityType></securityType>
+      </InstalledPackage>`;
+
+      it('returns an empty string', () => {
+        const installedPackage = new InstalledPackage(fileName, xml);
+        expect(installedPackage.securityType).to.equal('');
+      });
+    });
+
+    context('when <securityType> element is not present', () => {
+      const xml = `<?xml version="1.0" encoding="UTF-8"?>
+      <InstalledPackage xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+          <versionNumber>1.23</versionNumber>
+      </InstalledPackage>`;
+
+      it('returns undefined', () => {
+        const installedPackage = new InstalledPackage(fileName, xml);
+        expect(installedPackage.securityType).to.equal(undefined);
       });
     });
   });

--- a/src/metadata_browser/installedPackage.ts
+++ b/src/metadata_browser/installedPackage.ts
@@ -6,8 +6,8 @@ export class InstalledPackage extends MetadataComponent {
   protected readonly metadataType = 'InstalledPackage';
 
   // Gets the value of the <activateRSS> element
-  // Returns true/false if there is a value, or null if there is no value
-  // Returns undefined if the element does not exist
+  // Returns true/false if there is a value; null if there is no value
+  // Returns undefined if the element does not exist, or the value is not a valid boolean
   public get activateRSS(): Nullable<boolean> {
     if (hasBoolean(this.metadata, 'activateRSS')) {
       return getBoolean(this.metadata, 'activateRSS');
@@ -17,5 +17,12 @@ export class InstalledPackage extends MetadataComponent {
     } else {
       return undefined;
     }
+  }
+
+  // Gets the value of the <securityType> element
+  // Returns the value as a string, or an empty string if there is no value
+  // Returns undefined if the element does not exist
+  public get securityType(): Nullable<string> {
+    return getString(this.metadata, 'securityType');
   }
 }

--- a/src/metadata_browser/installedPackage.ts
+++ b/src/metadata_browser/installedPackage.ts
@@ -1,0 +1,21 @@
+import { getBoolean, getString, hasBoolean, Nullable } from '@salesforce/ts-types';
+import { MetadataComponent } from './metadataComponent';
+
+export class InstalledPackage extends MetadataComponent {
+  protected readonly fileExtension = 'installedPackage';
+  protected readonly metadataType = 'InstalledPackage';
+
+  // Gets the value of the <activateRSS> element
+  // Returns true/false if there is a value, or null if there is no value
+  // Returns undefined if the element does not exist
+  public get activateRSS(): Nullable<boolean> {
+    if (hasBoolean(this.metadata, 'activateRSS')) {
+      return getBoolean(this.metadata, 'activateRSS');
+    } else if (getString(this.metadata, 'activateRSS') === '') {
+      // this happens when <activateRSS xsi:nil="true"/>
+      return null;
+    } else {
+      return undefined;
+    }
+  }
+}

--- a/src/metadata_browser/sfdxProjectBrowser.test.ts
+++ b/src/metadata_browser/sfdxProjectBrowser.test.ts
@@ -5,6 +5,21 @@ import * as sinon from 'sinon';
 import { SfdxProjectBrowser } from './sfdxProjectBrowser';
 
 describe('SfdxProjectBrowser', () => {
+  describe('.installedPackages()', () => {
+    it('returns an array of InstalledPackage objects', () => {
+      const sfdxProjectBrowser = new SfdxProjectBrowser(null);
+      const mockProjectBrowser = sinon.mock(sfdxProjectBrowser);
+      mockProjectBrowser.expects('installedPackageDir').once().returns('src/test/metadata/installedPackages');
+
+      const results = sfdxProjectBrowser.installedPackages();
+      expect(results.length).to.equal(3);
+      expect(results[0].name).to.equal('TestPackageA');
+      expect(results[1].name).to.equal('TestPackageB');
+      expect(results[2].name).to.equal('TestPackageC');
+      mockProjectBrowser.verify();
+    });
+  });
+
   describe('.lwcBundles()', () => {
     it('returns an array of LightningComponentBundle objects', () => {
       const sfdxProjectBrowser = new SfdxProjectBrowser(null);

--- a/src/metadata_browser/sfdxProjectBrowser.ts
+++ b/src/metadata_browser/sfdxProjectBrowser.ts
@@ -4,6 +4,7 @@ import { SfdxProject } from '@salesforce/core';
 import { CustomField } from './customField';
 import { CustomObject } from './customObject';
 import { EmailToCaseSettings } from './emailToCaseSettings';
+import { InstalledPackage } from './installedPackage';
 import { LightningComponentBundle } from './lightningComponentBundle';
 import { PicklistField } from './picklistField';
 import { Profile } from './profile';
@@ -55,6 +56,12 @@ export class SfdxProjectBrowser {
       return this.fieldsForObject(objectName).concat(fieldsFromActivityObject);
     }
     return this.fieldsForObject(objectName);
+  }
+
+  public installedPackages(): InstalledPackage[] {
+    const dir = this.installedPackageDir();
+    const fileNames = fs.existsSync(dir) ? fs.readdirSync(dir) : [];
+    return fileNames.map((f) => new InstalledPackage(path.join(dir, f)));
   }
 
   // Return a map of all LWCs. key = LWC name, value = full path to the folder that contains all the components for that LWC
@@ -117,6 +124,10 @@ export class SfdxProjectBrowser {
           object.isExternalObject()
       )
       .filter((object) => !this.OBJECTS_TO_IGNORE.includes(object.name));
+  }
+
+  private installedPackageDir(): string {
+    return path.join(this.defaultDir(), 'installedPackages');
   }
 
   private lwcBaseDir(): string {

--- a/src/ruleset/installedPackageRuleset.test.ts
+++ b/src/ruleset/installedPackageRuleset.test.ts
@@ -1,0 +1,36 @@
+import 'mocha';
+import { expect } from 'chai';
+import sinon = require('sinon');
+import { SfdxProjectBrowser } from '../metadata_browser/sfdxProjectBrowser';
+import { InstalledPackage } from '../metadata_browser/installedPackage';
+import { InstalledPackageRuleset } from './installedPackageRuleset';
+
+describe('InstalledPackageRuleset', () => {
+  describe('.run()', () => {
+    const goodInstalledPackage = new InstalledPackage(
+      'src/test/metadata/installedPackages/TestPackageA.installedPackage-meta.xml'
+    );
+    const badInstalledPackage = new InstalledPackage(
+      'src/test/metadata/installedPackages/TestPackageB.installedPackage-meta.xml'
+    );
+    const anotherBadInstalledPackage = new InstalledPackage(
+      'src/test/metadata/installedPackages/TestPackageC.installedPackage-meta.xml'
+    );
+
+    it('returns an error if the <activateRSS> element is empty', () => {
+      const sfdxProjectBrowser = new SfdxProjectBrowser(null);
+      sinon
+        .stub(sfdxProjectBrowser, 'installedPackages')
+        .returns([goodInstalledPackage, badInstalledPackage, anotherBadInstalledPackage]);
+
+      const ruleset = new InstalledPackageRuleset(sfdxProjectBrowser);
+      const results = ruleset.run();
+
+      expect(results.length).to.equal(2);
+      expect(results[0].problemType).to.equal('Error');
+      expect(results[0].problem).to.equal('<activateRSS> element is empty. Should contain a boolean value');
+      expect(results[1].problemType).to.equal('Error');
+      expect(results[1].problem).to.equal('<activateRSS> element does not exist, or contains a non-boolean value');
+    });
+  });
+});

--- a/src/ruleset/installedPackageRuleset.ts
+++ b/src/ruleset/installedPackageRuleset.ts
@@ -1,0 +1,45 @@
+import { InstalledPackage } from '../metadata_browser/installedPackage';
+import { MetadataError, MetadataProblem } from './metadataProblem';
+import { MetadataRuleset } from './metadataRuleset';
+
+export class InstalledPackageRuleset extends MetadataRuleset {
+  public displayName = 'Installed packages';
+
+  public run(): MetadataProblem[] {
+    return this.sfdxProjectBrowser
+      .installedPackages()
+      .map((p) => this.installedPackageErrors(p))
+      .flat();
+  }
+
+  private installedPackageErrors(installedPackage: InstalledPackage): MetadataError[] {
+    const results: MetadataError[] = [];
+
+    if (installedPackage.activateRSS === null) {
+      results.push(this.activateRssNullError(installedPackage));
+    }
+    if (installedPackage.activateRSS === undefined) {
+      results.push(this.activateRssUndefinedError(installedPackage));
+    }
+
+    return results;
+  }
+
+  private activateRssNullError(installedPackage: InstalledPackage): MetadataError {
+    return new MetadataError(
+      installedPackage.name,
+      'InstalledPackage',
+      installedPackage.fileName,
+      '<activateRSS> element is empty. Should contain a boolean value'
+    );
+  }
+
+  private activateRssUndefinedError(installedPackage: InstalledPackage): MetadataError {
+    return new MetadataError(
+      installedPackage.name,
+      'InstalledPackage',
+      installedPackage.fileName,
+      '<activateRSS> element does not exist, or contains a non-boolean value'
+    );
+  }
+}

--- a/src/test/metadata/installedPackages/TestPackageA.installedPackage-meta.xml
+++ b/src/test/metadata/installedPackages/TestPackageA.installedPackage-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<InstalledPackage xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <activateRSS>false</activateRSS>
+    <versionNumber>5.19</versionNumber>
+</InstalledPackage>

--- a/src/test/metadata/installedPackages/TestPackageB.installedPackage-meta.xml
+++ b/src/test/metadata/installedPackages/TestPackageB.installedPackage-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<InstalledPackage xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <activateRSS xsi:nil="true"/>
+    <versionNumber>1.1</versionNumber>
+</InstalledPackage>

--- a/src/test/metadata/installedPackages/TestPackageC.installedPackage-meta.xml
+++ b/src/test/metadata/installedPackages/TestPackageC.installedPackage-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<InstalledPackage xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <!-- no <activateRSS> element at all -->
+	<versionNumber>3.142</versionNumber>
+</InstalledPackage>


### PR DESCRIPTION
### Description

New ruleset for Installed Packages.

Raises a metadata error if **activateRSS** element is 
* empty e.g. `<activateRSS xsi:nil="true"/>` or `<activateRSS></activateRSS>`
* missing altogether, or invalid e.g. `<activateRSS>17</activateRSS>`

Does nothing (will not raise any errors) if there are no installed packages in the project.

### Default behaviour

This rule is **on** by default. Specifically, it run if not explicitly enabled or disabled in the `.dxcoprc` config file.